### PR TITLE
Remove BASIC authentication from POST request

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -151,7 +151,7 @@ Cam.prototype._request = function(options, callback) {
 		, 'Content-Length': options.body.length
 		, charset: 'utf-8'
 	};
-	reqOptions.auth = this.username + ':' + this.password;
+	
 	reqOptions.method = 'POST';
 	var req = http.request(reqOptions, function(res) {
 		var bufs = [], length = 0;


### PR DESCRIPTION
The authentication fail with my TRENDNET cameras. 

With the help of wireshark, i discover a BASIC Authorization in the POST request not compatible, i guess, with the  SOAP Security processus.

If i remove "reqOptions.auth = this.username + ':' + this.password;", the authentication success.