### PR TITLE
preventing node app crash on socket connection error

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -174,6 +174,9 @@ Cam.prototype._request = function(options, callback) {
 		/* address, port number or IPCam error */
 		if (err.code === 'ECONNREFUSED' && err.errno === 'ECONNREFUSED'  && err.syscall === 'connect') {
 			console.error(err);
+		/* network error */
+		} else if (err.code === 'ECONNRESET' && err.errno === 'ECONNRESET'  && err.syscall === 'read') {
+			console.error(err);
 		} else {
 			callback(err);
 		}


### PR DESCRIPTION
preventing node app crash on socket connection error or wrong IP address
crash: [TypeError: Cannot read property 'device' of undefined]