### PR TITLE
Improve SOAP parsing

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -56,6 +56,10 @@ const linerase = function(xml) {
  * @param {ParseSOAPStringCallback} callback
  */
 const parseSOAPString = function(xml, callback) {
+
+        /* Filter out xml name spaces */
+        xml = xml.replace(/xmlns(.*?)=(".*?")/g,'');
+
 	xml2js.parseString(
 		xml
 		, {


### PR DESCRIPTION
This commit improves parsing of SOAP replies with XMLNS name space attributes in the tag.
When an XMLNS is present (as they are with the SOAP replies from the RPOS ONVIF NVT) they cause the data structure created by XML2JS to be generated differently.
This in turn causes problems trying to extract values from the ONVIF SOAP replies (like the RTSP URI).

The best fix would be to change xml2js to tell it to ignore xmlns attributes (but keep other attributes) but the simple fix is to filter the SOAP XML before passing it to xml2js
