### PR TITLE
allow valid multicast parameter values

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -274,9 +274,9 @@ Cam.prototype.setVideoEncoderConfiguration = function(options, callback) {
 						( options.multicast.address.IPv6Address ? '<IPv6Address>' + options.multicast.address.IPv6Address + '</IPv6Address>' : '')
 					) +
 				'</Address>' : '') +
-				( options.multicast.port ? '<Port>' + options.multicast.port + '</Port>' : '' ) +
-				( options.multicast.TTL ? '<TTL>' + options.multicast.TTL + '</TTL>' : '') +
-				( options.multicast.autoStart ? '<AutoStart>' + options.multicast.autoStart + '</AutoStart>' : '') +
+				( (options.multicast.port || options.multicast.port === 0) ? '<Port>' + options.multicast.port + '</Port>' : '' ) +
+				( (options.multicast.TTL || options.multicast.TTL === 0) ? '<TTL>' + options.multicast.TTL + '</TTL>' : '') +
+				( (options.multicast.autoStart || options.multicast.autoStart === false) ? '<AutoStart>' + options.multicast.autoStart + '</AutoStart>' : '') +
 			'</Multicast>' : '' ) +
 			( options.sessionTimeout ?
 			'<SessionTimeout xmlns="http://www.onvif.org/ver10/schema">' +


### PR DESCRIPTION
TTL and port can now be 0 and autoStart can now be false, which are all valid values.