### PR TITLE
Fix GetScopes bug reported by Matthew Lien

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -634,7 +634,7 @@ Cam.prototype.getDeviceInformation = function(callback) {
 Cam.prototype.getHostname = function(callback) {
 	this._request({
 		body: this._envelopeHeader() +
-		'<GetHostname xmlns="http://www.onvif.org/ver10/device/wsdl"/></GetHostname>' +
+		'<GetHostname xmlns="http://www.onvif.org/ver10/device/wsdl"></GetHostname>' +
 		this._envelopeFooter()
 	}, function(err, data, xml) {
 		if (callback) {

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -663,7 +663,7 @@ Cam.prototype.getHostname = function(callback) {
 Cam.prototype.getScopes = function(callback) {
 	this._request({
 		body: this._envelopeHeader() +
-		'<GetScopes xmlns="http://www.onvif.org/ver10/device/wsdl"/></GetScopes>' +
+		'<GetScopes xmlns="http://www.onvif.org/ver10/device/wsdl"></GetScopes>' +
 		this._envelopeFooter()
 	}, function(err, data, xml) {
 		if (!err) {


### PR DESCRIPTION
There was an incorrect closing of an XML tag.
A bug report was filed in the RPOS Project [https://github.com/BreeeZe/rpos/issues/16](https://github.com/BreeeZe/rpos/issues/16) my Matthew Lien reporting some issues between agsh/onvif and RPOS.
