### PR TITLE
Allow empty username and password

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -75,12 +75,7 @@ var Cam = function(options, callback) {
 
 	this.events = {};
 
-	if (this.username && this.password) {
-		this.connect(callback);
-	} else {
-		console.warn('Empty username or password');
-		this.connect(callback);
-	}
+	this.connect(callback);
 };
 
 // events.EventEmitter inheritance
@@ -756,21 +751,21 @@ Cam.prototype._passwordDigest = function() {
  */
 Cam.prototype._envelopeHeader = function() {
 	var header = '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">' +
-		     '<s:Header>';
+			'<s:Header>';
 	// Only insert Security if there is a username and password
 	if (this.username && this.password) {
 		var req = this._passwordDigest();
 		header += '<Security s:mustUnderstand="1" xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">' +
-			  '<UsernameToken>' +
-			  '<Username>' + this.username + '</Username>' +
-			  '<Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">' + req.passdigest + '</Password>' +
-			  '<Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">' + req.nonce + '</Nonce>' +
-			  '<Created xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">' + req.timestamp + '</Created>' +
-			  '</UsernameToken>' +
-			  '</Security>' 
-	};
+			'<UsernameToken>' +
+			'<Username>' + this.username + '</Username>' +
+			'<Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">' + req.passdigest + '</Password>' +
+			'<Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">' + req.nonce + '</Nonce>' +
+			'<Created xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">' + req.timestamp + '</Created>' +
+			'</UsernameToken>' +
+			'</Security>';
+	}
 	header += '</s:Header>' +
-		  '<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">';
+			'<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">';
 	return header;
 };
 

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -78,7 +78,8 @@ var Cam = function(options, callback) {
 	if (this.username && this.password) {
 		this.connect(callback);
 	} else {
-		callback(new Error('Missing username or password'));
+		console.warn('Empty username or password');
+		this.connect(callback);
 	}
 };
 
@@ -754,19 +755,23 @@ Cam.prototype._passwordDigest = function() {
  * @private
  */
 Cam.prototype._envelopeHeader = function() {
-	var req = this._passwordDigest();
-	return '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">' +
-		'<s:Header>' +
-		'<Security s:mustUnderstand="1" xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">' +
-		'<UsernameToken>' +
-		'<Username>' + this.username + '</Username>' +
-		'<Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">' + req.passdigest + '</Password>' +
-		'<Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">' + req.nonce + '</Nonce>' +
-		'<Created xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">' + req.timestamp + '</Created>' +
-		'</UsernameToken>' +
-		'</Security>' +
-		'</s:Header>' +
-		'<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">';
+	var header = '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">' +
+		     '<s:Header>';
+	// Only insert Security if there is a username and password
+	if (this.username && this.password) {
+		var req = this._passwordDigest();
+		header += '<Security s:mustUnderstand="1" xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">' +
+			  '<UsernameToken>' +
+			  '<Username>' + this.username + '</Username>' +
+			  '<Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">' + req.passdigest + '</Password>' +
+			  '<Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">' + req.nonce + '</Nonce>' +
+			  '<Created xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">' + req.timestamp + '</Created>' +
+			  '</UsernameToken>' +
+			  '</Security>' 
+	};
+	header += '</s:Header>' +
+		  '<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">';
+	return header;
 };
 
 /**


### PR DESCRIPTION
This change allows connecting to a NVT with an empty username and empty password.
Was testing with an ONVIF NVT which was set to no authentication. However this NVT complained when WS-Security (with empty username/password) was sent.
The empty username and password check is removed and WS-Security is only used when there is a username and password