### PR TITLE
Fixed #55: Discovery with multiple network interfaces

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -137,13 +137,13 @@ Discovery.probe = function(options, callback) {
 	};
 
 	// If device is specified try to bind to that interface
-	if(options.device) {
+	if (options.device) {
 		var interfaces = os.networkInterfaces();
 		// Try to find the interface based on the device name
-		if(interfaces[options.device]) {
+		if (interfaces[options.device]) {
 			interfaces[options.device].some(function(address) {
 				// Only use IPv4 addresses
-				if(address.family === 'IPv4') {
+				if (address.family === 'IPv4') {
 					socket.bind(3702, address.address);
 					return true;
 				}

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -12,6 +12,7 @@ const
 	, linerase = require('./utils').linerase
 	, parseSOAPString = require('./utils').parseSOAPString
 	, url = require('url')
+	, os = require('os')
 	;
 
 /**
@@ -33,6 +34,7 @@ var Discovery = Object.create(new events.EventEmitter());
  * @param {number} [options.timeout=5000] timeout in milliseconds for discovery responses
  * @param {boolean} [options.resolve=true] set to `false` if you want omit creating of Cam objects
  * @param {string} [options.messageId=GUID] WS-Discovery message id
+ * @param {string} [options.device=defaultroute] Interface to bind on for discovery ex. `eth0`
  * @param {Discovery~ProbeCallback} [callback] timeout callback
  * @fires Discovery#device
  * @fires Discovery#error
@@ -133,6 +135,23 @@ Discovery.probe = function(options, callback) {
 			}
 		});
 	};
+
+	// If device is specified try to bind to that interface
+	if(options.device) {
+		var interfaces = os.networkInterfaces();
+		// Try to find the interface based on the device name
+		if(interfaces[options.device]) {
+			interfaces[options.device].some(function(address) {
+				// Only use IPv4 addresses
+				if(address.family === 'IPv4') {
+					socket.bind(3702, address.address);
+					return true;
+				}
+				
+				return false;
+			});
+		}
+	}
 
 	socket.on('message', listener);
 	socket.send(request, 0, request.length, 3702, '239.255.255.250');

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -144,7 +144,7 @@ Discovery.probe = function(options, callback) {
 			interfaces[options.device].some(function(address) {
 				// Only use IPv4 addresses
 				if (address.family === 'IPv4') {
-					socket.bind(3702, address.address);
+					socket.bind(null, address.address);
 					return true;
 				}
 				

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -142,13 +142,14 @@ Discovery.probe = function(options, callback) {
 		// Try to find the interface based on the device name
 		if (options.device in interfaces) {
 			interfaces[options.device].some(function(address) {
+				var result = false;
 				// Only use IPv4 addresses
 				if (address.family === 'IPv4') {
 					socket.bind(null, address.address);
-					return true;
+					result = true;
 				}
 				
-				return false;
+				return result;
 			});
 		}
 	}

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -140,7 +140,7 @@ Discovery.probe = function(options, callback) {
 	if (options.device) {
 		var interfaces = os.networkInterfaces();
 		// Try to find the interface based on the device name
-		if (interfaces[options.device]) {
+		if (options.device in interfaces) {
 			interfaces[options.device].some(function(address) {
 				// Only use IPv4 addresses
 				if (address.family === 'IPv4') {

--- a/test/discovery.coffee
+++ b/test/discovery.coffee
@@ -51,7 +51,6 @@ describe 'Discovery', () ->
       assert.equal Object.keys(cams).length, cCams.length
       onvif.Discovery.removeListener('device', onCam)
       done()
-
   it 'should got single device for one probe when `lo` is specified', (done) ->
     cams = {}
     onCam = (data) ->
@@ -60,7 +59,20 @@ describe 'Discovery', () ->
       else
         cams[data.probeMatches.probeMatch.XAddrs] = true
     onvif.Discovery.on 'device', onCam
-    onvif.Discovery.probe {timeout: 1000, resolve: false, messageId: 'cl1m@x', device: 'lo'}, (err, cCams) ->
+    onvif.Discovery.probe {timeout: 1000, resolve: false, device: 'lo'}, (err, cCams) ->
+      assert.equal err, null
+      assert.equal Object.keys(cams).length, cCams.length
+      onvif.Discovery.removeListener('device', onCam)
+      done()
+  it 'should got single device for one probe even when bogus device is specified (fallback to defaultroute)', (done) ->
+    cams = {}
+    onCam = (data) ->
+      if cams[data.probeMatches.probeMatch.XAddrs]
+        assert.fail()
+      else
+        cams[data.probeMatches.probeMatch.XAddrs] = true
+    onvif.Discovery.on 'device', onCam
+    onvif.Discovery.probe {timeout: 1000, resolve: false, device: 'loopydevice'}, (err, cCams) ->
       assert.equal err, null
       assert.equal Object.keys(cams).length, cCams.length
       onvif.Discovery.removeListener('device', onCam)

--- a/test/discovery.coffee
+++ b/test/discovery.coffee
@@ -51,3 +51,17 @@ describe 'Discovery', () ->
       assert.equal Object.keys(cams).length, cCams.length
       onvif.Discovery.removeListener('device', onCam)
       done()
+
+  it 'should got single device for one probe when `lo` is specified', (done) ->
+    cams = {}
+    onCam = (data) ->
+      if cams[data.probeMatches.probeMatch.XAddrs]
+        assert.fail()
+      else
+        cams[data.probeMatches.probeMatch.XAddrs] = true
+    onvif.Discovery.on 'device', onCam
+    onvif.Discovery.probe {timeout: 1000, resolve: false, messageId: 'cl1m@x', device: 'lo'}, (err, cCams) ->
+      assert.equal err, null
+      assert.equal Object.keys(cams).length, cCams.length
+      onvif.Discovery.removeListener('device', onCam)
+      done()

--- a/test/serverMockup.coffee
+++ b/test/serverMockup.coffee
@@ -48,6 +48,7 @@ discover.msg =
   )
 discover.on 'error', (err) -> throw err
 discover.on 'message', (msg, rinfo) ->
+  console.log(msg)
   msgId = /urn:uuid:([0-9a-f\-]+)</.exec(msg.toString())[1]
   if msgId
     switch msgId


### PR DESCRIPTION
Allows to specify an optional device name such as `eth0`