### PR TITLE
Implementation network interfaces method

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -658,6 +658,140 @@ Cam.prototype.getDeviceInformation = function(callback) {
 };
 
 /**
+ * @typedef {object} Cam~NetworkInterfaces
+ * @property {ReferenceToken} token  Unique identifier referencing the physical entity.
+ * @property {boolean} enabled Indicates whether or not an interface is enabled.
+ * @property {NetworkInterfaceInfo} Network interface information
+ * @property {string} Name  Network interface name, for example eth0
+ * @property {HwAddress} HwAddress Network interface MAC address
+ * @property {int} MTU Maximum transmission unit.
+ * @property {NetworkInterfaceLink} Link Link configuration.
+ * @property {NetworkInterfaceConnectionSetting}AdminSettings Configured link settings.
+ * @property {boolean} AutoNegotiation Auto negotiation on/off.
+ * @property {int} Speed.
+ * @property {Duplex} Duplex type, Half or Full. - enum { 'Full', 'Half' }
+ * @property {int} InterfaceType Integer indicating interface type, for example: 6 is ethernet.
+ * @property {IPv4NetworkInterface} IPv4 IPv4 network interface configuration.
+ * @property {boolean} Enabled Indicates whether or not IPv4 is enabled.
+ * @property {IPv4Configuration} Config  IPv4 configuration.
+ * @property {PrefixedIPv4Address} Manual List of manually added IPv4 addresses.
+ * @property {IPv4Address} Address IPv4 address.
+ * @property {int} PrefixLength Prefix/submask length. 	
+ * @property {PrefixedIPv4Address} LinkLocal  List of manually added IPv4 addresses.
+ * @property {IPv4Address} Address IPv4 address.
+ * @property {int} PrefixLength Prefix/submask length.
+ * @property {PrefixedIPv4Address} FromDHCP   List of manually added IPv4 addresses.
+ * @property {IPv4Address} Address IPv4 address.
+ * @property {int} PrefixLength Prefix/submask length.
+ * @property {boolean} DHCP Indicates whether or not DHCP is used.
+ * @property {IPv6NetworkInterface} IPv6 
+ * @property {boolean} Enabled Indicates whether or not IPv6 is enabled.
+ * @property {IPv4Configuration} Config  IPv6 configuration.
+ * @property {boolean} AcceptRouterAdvert Indicates whether router advertisment is used.
+ * @property {IPv6DHCPConfiguration} DHCP DHCP configuration.
+ * @property {PrefixedIPv6Address} Manual List of manually added IPv4 addresses.
+ * @property {IPv4Address} Address IPv6 address.
+ * @property {int} PrefixLength Prefix/submask length. 	
+ * @property {PrefixedIPv6Address} LinkLocal  List of manually added IPv6 addresses.
+ * @property {IPv6Address} Address IPv6 address.
+ * @property {int} PrefixLength Prefix/submask length.
+ * @property {PrefixedIPv4Address} FromDHCP   List of manually added IPv6 addresses.
+ * @property {IPv6Address} Address IPv6 address.
+ * @property {int} PrefixLength Prefix/submask length.
+ * @property {PrefixedIPv6Address} FromRA List of IPv6 addresses configured by using router advertisment.
+ * @property {IPv6Address} Address IPv6 address.
+ * @property {int} PrefixLength Prefix/submask length.
+ * @property {IPv6ConfigurationExtension} Extension.
+ * @property {IANA-IfTypes} InterfaceType 
+ * @property {Dot3Configuration} Dot3 Extension point prepared for future 802.3 configuration.
+ * @property {Dot11Configuration} Dot11 
+ * @property {Dot11SSIDType} SSID 
+ * @property {Dot11StationMode} Mode - enum { 'Ad-hoc', 'Infrastructure', 'Extended' }
+ * @property {Name} Alias 
+ * @property {NetworkInterfaceConfigPriority} Priority 
+ * @property {Dot11SecurityConfiguration} Security 
+ * @property {Dot11SecurityMode} Mode  - enum { 'None', 'WEP', 'PSK', 'Dot1X', 'Extended'   
+ * @property {Dot11Cipher} Algorithm - enum { 'CCMP', 'TKIP', 'Any', 'Extended' }
+ * @property {Dot11PSKSet} PSK 
+ * @property {Dot11PSK} Key According to IEEE802.11-2007 H.4.1 the RSNA PSK consists of 256 bits, or 64 octets when represented in hex
+ *						Either Key or Passphrase shall be given, if both are supplied Key shall be used by the device and Passphrase ignored.
+ * @property {Dot11PSKPassphrase} Passphrase According to IEEE802.11-2007 H.4.1 a pass-phrase is a sequence of between 8 and 63 ASCII-encoded characters and each character in the pass-phrase must have an encoding in the range of 32 to 126 (decimal),inclusive.
+ *											 if only Passpharse is supplied the Key shall be derived using the algorithm described in IEEE802.11-2007 section H.4
+ * @property {Dot11PSKSetExtension} Extension 
+ * @property {ReferenceToken} Dot1X 
+ * @property {Dot11SecurityConfigurationExtension} Extension 
+ */
+
+/**
+ * @callback Cam~GetNetworkInterfacesCallback
+ * @property {?Error} error
+ * @property {Cam~NetworkInterfaces} network interface information
+ * @property {string} xml Raw SOAP response
+ */
+
+/**
+ * Receive network interfaces information
+ * @param {Cam~NetworkInterfacesCallback} [callback]
+ */
+Cam.prototype.getNetworkInterfaces = function(callback) {
+	this._request({
+		body: this._envelopeHeader() +
+		'<GetNetworkInterfaces xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
+		this._envelopeFooter()
+	}, function(err, data, xml) {
+		
+		if(!err)
+			this.networkInterfaces = linerase(data).getNetworkInterfacesResponse;
+		else
+			console.log("err");
+		if(callback) {
+			callback.call(this,err,this.networkInterfaces,xml);
+		}
+		
+	}.bind(this));
+	
+}
+
+/**
+ * @typedef {object} Cam~NetworkProtocols
+ * @property {NetworkProtocolType} Name Network protocol type string. - enum { 'HTTP', 'HTTPS', 'RTSP' }
+ * @property {boolean} Enabled Indicates if the protocol is enabled or not.
+ * @property {int} Port The port that is used by the protocol.
+ * @property {NetworkProtocolExtension} Extension 
+ */
+
+/**
+ * @callback Cam~GetNetworkProtocolsCallback
+ * @property {?Error} error
+ * @property {Cam~NetworkProtocols} network protocols information
+ * @property {string} xml Raw SOAP response
+ */
+
+/**
+ * Receive network protocols information
+ * @param {Cam~NetworkProcolsCallback} [callback]
+ */
+
+Cam.prototype.getNetworkProtocols = function(callback) {
+	this._request({
+		body: this._envelopeHeader() +
+		'<GetNetworkProtocols xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
+		this._envelopeFooter()
+	}, function(err, data, xml) {
+		
+		if(!err) 
+			this.networkProtocols = linerase(data).getNetworkProtocolsResponse;
+		else
+			console.log("err");
+		if(callback) {
+			callback.call(this,err,this.networkProtocols,xml);
+		}
+		
+	}.bind(this));
+	
+}
+
+/**
  * @typedef {object} Cam~HostnameInformation
  * @property {boolean} fromDHCP Indicates whether the hostname is obtained from DHCP or not
  * @property {string} [name] Indicates the hostname


### PR DESCRIPTION
Added compatibility methods:

-GetNetworkInterfaces
http://www.onvif.org/ver10/device/wsdl/GetNetworkInterfaces

-GetNetworkProtocols
http://www.onvif.org/ver10/device/wsdl/GetNetworkProtocols

These methods add very usefull information about network interface of the device such as MAC address, IP version, configured protocol...
