### PR TITLE
added support for HTTP agents (socks5, etc)

### DIFF
--- a/example5.js
+++ b/example5.js
@@ -1,0 +1,51 @@
+/**
+ * Created by Andrew D.Laptev<a.d.laptev@gmail.com> on 1/21/15.
+ * Edited by Lucas Zanella <me@lucaszanella.com> on 27/08/17.
+ * Same as example.json but uses SOCKS5 (useful to access cameras securely through SSH)
+ */
+var ProxyAgent = require('proxy-agent');
+
+var CAMERA_HOST = '192.168.1.164',
+	USERNAME = 'admin',
+	PASSWORD = 'admin',
+	PORT = 1018,
+	PROXY_URI = 'socks5://localhost:1234';
+
+
+var http = require('http'),
+  	Cam = require('./onvif').Cam;
+
+new Cam({
+	hostname: CAMERA_HOST,
+	username: USERNAME,
+	password: PASSWORD,
+	port: PORT,
+	agent: new ProxyAgent(PROXY_URI)
+}, function(err) {
+	if (err) {
+		console.log('Connection Failed for ' + CAMERA_HOST + ' Port: ' + PORT + ' Username: ' + USERNAME + ' Password: ' + PASSWORD);
+		return;
+	}
+	console.log('CONNECTED');
+	
+	this.absoluteMove({
+		x: 1
+		, y: 1
+		, zoom: 1
+	});
+	
+	this.getStreamUri({protocol:'RTSP'}, function(err, stream) {
+		console.log(stream);
+		
+		http.createServer(function (req, res) {
+			res.writeHead(200, {'Content-Type': 'text/html'});
+			res.end(
+				'<html><body>' +
+				'<embed type="application/x-vlc-plugin" target="' + stream.uri + '"></embed>' +
+				'</boby></html>');
+		}).listen(3030);
+		
+	});
+	
+});
+

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -74,6 +74,7 @@ var Cam = function(options, callback) {
 	this.port = options.port || 80;
 	this.path = options.path || '/onvif/device_service';
 	this.timeout = options.timeout || 120000;
+	this.agent = options.agent || false;
 	/**
 	 * Force using hostname and port from constructor for the services
 	 * @type {boolean}
@@ -114,7 +115,6 @@ Cam.prototype.connect = function(callback) {
 					upstartFunctions.push(this.getProfiles);
 					upstartFunctions.push(this.getVideoSources);
 				}
-
 				var count = upstartFunctions.length;
 				var errCall = false;
 
@@ -171,6 +171,7 @@ Cam.prototype._request = function(options, callback) {
 	var reqOptions = options.url || {
 			hostname: this.hostname
 			, port: this.port
+			, agent: this.agent //Supports things like https://www.npmjs.com/package/proxy-agent which provide SOCKS5 and other connections
 			, path: options.service
 				? (this.uri[options.service] ? this.uri[options.service].path : options.service)
 				: this.path


### PR DESCRIPTION
HTTP agents are useful, specially if you need to connect to your cameras through SSH. Instead of forwarding a bunch of ports you just open a secure SOCKS proxy :)

Also added examples5.json which connects through proxy to the camera