### PR TITLE
Removes cylic dependencies so it can be used in React Native

### DIFF
--- a/example.js
+++ b/example.js
@@ -10,6 +10,7 @@ var CAMERA_HOST = '192.168.68.111',
 var http = require('http'),
 	Cam = require('./lib/onvif').Cam;
 
+
 new Cam({
 	hostname: CAMERA_HOST,
 	username: USERNAME,

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -855,10 +855,10 @@ module.exports = {
 };
 
 // extending Camera prototype
-require('./device');
-require('./events');
-require('./media');
-require('./ptz');
-require('./imaging');
-require('./recording');
-require('./replay');
+require('./device' )  (Cam);
+require('./events')   (Cam);
+require('./media')    (Cam);
+require('./ptz')      (Cam);
+require('./imaging')  (Cam);
+require('./recording')(Cam);
+require('./replay')   (Cam);

--- a/lib/device.js
+++ b/lib/device.js
@@ -4,203 +4,202 @@
  * @author Andrew D.Laptev <a.d.laptev@gmail.com>
  * @licence MIT
  */
+module.exports = (Cam) => {
+	const linerase = require('./utils').linerase;
 
-const Cam = require('./cam').Cam
-	, linerase = require('./utils').linerase
-	;
+	/**
+	 * @typedef {object} Cam~NTPInformation
+	 * @property {boolean} fromDHCP Indicates if NTP information is to be retrieved by using DHCP
+	 * @property {object} [NTPFromDHCP] List of NTP addresses retrieved by using DHCP
+	 * @property {object} [NTPManual] List of manually entered NTP addresses
+	 */
 
-/**
- * @typedef {object} Cam~NTPInformation
- * @property {boolean} fromDHCP Indicates if NTP information is to be retrieved by using DHCP
- * @property {object} [NTPFromDHCP] List of NTP addresses retrieved by using DHCP
- * @property {object} [NTPManual] List of manually entered NTP addresses
- */
+	/**
+	 * @callback Cam~NTPCallback
+	 * @property {?Error} error
+	 * @property {Cam~NTPInformation} NTP information object of current device's NTP manual
+	 * @property {string} xml Raw SOAP response
+	 */
 
-/**
- * @callback Cam~NTPCallback
- * @property {?Error} error
- * @property {Cam~NTPInformation} NTP information object of current device's NTP manual
- * @property {string} xml Raw SOAP response
- */
+	/**
+	 * Receive NTP information from cam
+	 * @param {Cam~NTPCallback} callback
+	 */
+	Cam.prototype.getNTP = function(callback) {
+		this._request({
+			service: 'device'
+			, body: this._envelopeHeader() +
+			'<GetNTP xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
+			'</s:Body>' +
+			'</s:Envelope>'
+		}, function(err, data, xml) {
+			if (!err) {
+				this.NTP = linerase(data[0]['getNTPResponse'][0]['NTPInformation'][0]);
+			}
+			callback.call(this, err, err ? null : this.NTP, xml);
+		});
+	};
 
-/**
- * Receive NTP information from cam
- * @param {Cam~NTPCallback} callback
- */
-Cam.prototype.getNTP = function(callback) {
-	this._request({
-		service: 'device'
-		, body: this._envelopeHeader() +
-		'<GetNTP xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
-		'</s:Body>' +
-		'</s:Envelope>'
-	}, function(err, data, xml) {
-		if (!err) {
-			this.NTP = linerase(data[0]['getNTPResponse'][0]['NTPInformation'][0]);
-		}
-		callback.call(this, err, err ? null : this.NTP, xml);
-	});
-};
+	/**
+	 * Set the NTP settings on a device
+	 * @param {object} options
+	 * @param {boolean} options.fromDHCP Indicate if NTP address information is to be retrieved using DHCP
+	 * @param {string} [options.type] Network host type: IPv4, IPv6 or DNS.
+	 * @param {string} [options.ipv4Address] IPv4 address
+	 * @param {string} [options.ipv6Address] IPv6 address
+	 * @param {string} [options.dnsName] DNS name
+	 * @param {string} [options.extension]
+	 * @param {Cam~RequestCallback} [callback]
+	 */
+	Cam.prototype.setNTP = function(options, callback) {
+		this._request({
+			service: 'device'
+			, body: this._envelopeHeader() +
+			'<SetNTP xmlns="http://www.onvif.org/ver10/device/wsdl">' +
+				'<FromDHCP>' + options.fromDHCP + '</FromDHCP>' +
+				( options.type ? '<NTPManual>' +
+					'<Type xmlns="http://www.onvif.org/ver10/schema">' + options.type + '</Type>' +
+					( options.ipv4Address ? '<IPv4Address xmlns="http://www.onvif.org/ver10/schema">' + options.ipv4Address + '</IPv4Address>' : '' ) +
+					( options.ipv6Address ? '<IPv6Address xmlns="http://www.onvif.org/ver10/schema">' + options.ipv6Address + '</IPv6Address>' : '' ) +
+					( options.dnsName ? '<DNSname>' + options.dnsName + '</DNSname>' : '' ) +
+					( options.extension ? '<Extension>' + options.extension + '</Extension>' : '' ) +
+				'</NTPManual>' : '') +
+			'</SetNTP>' +
+			this._envelopeFooter()
+		}, callback.bind(this));
+	};
 
-/**
- * Set the NTP settings on a device
- * @param {object} options
- * @param {boolean} options.fromDHCP Indicate if NTP address information is to be retrieved using DHCP
- * @param {string} [options.type] Network host type: IPv4, IPv6 or DNS.
- * @param {string} [options.ipv4Address] IPv4 address
- * @param {string} [options.ipv6Address] IPv6 address
- * @param {string} [options.dnsName] DNS name
- * @param {string} [options.extension]
- * @param {Cam~RequestCallback} [callback]
- */
-Cam.prototype.setNTP = function(options, callback) {
-	this._request({
-		service: 'device'
-		, body: this._envelopeHeader() +
-		'<SetNTP xmlns="http://www.onvif.org/ver10/device/wsdl">' +
-			'<FromDHCP>' + options.fromDHCP + '</FromDHCP>' +
-			( options.type ? '<NTPManual>' +
-				'<Type xmlns="http://www.onvif.org/ver10/schema">' + options.type + '</Type>' +
-				( options.ipv4Address ? '<IPv4Address xmlns="http://www.onvif.org/ver10/schema">' + options.ipv4Address + '</IPv4Address>' : '' ) +
-				( options.ipv6Address ? '<IPv6Address xmlns="http://www.onvif.org/ver10/schema">' + options.ipv6Address + '</IPv6Address>' : '' ) +
-				( options.dnsName ? '<DNSname>' + options.dnsName + '</DNSname>' : '' ) +
-				( options.extension ? '<Extension>' + options.extension + '</Extension>' : '' ) +
-			'</NTPManual>' : '') +
-		'</SetNTP>' +
-		this._envelopeFooter()
-	}, callback.bind(this));
-};
+	/**
+	 * @typedef {object} Cam~NetworkInterface
+	 * @property {string} token Unique identifier referencing the physical entity.
+	 * @property {boolean} enabled Indicates whether or not an interface is enabled.
+	 * @property {object} [info] network interface information
+	 * @property {string} info.name Network interface name, for example eth0
+	 * @property {string} info.hwAddress Network interface MAC address
+	 * @property {number} info.MTU Maximum transmission unit.
+	 * @property {object} [link] Link configuration.
+	 * @property {object} link.adminSettings Configured link settings.
+	 * @property {boolean} link.adminSettings.autoNegotiation Auto negotiation on/off.
+	 * @property {number} link.adminSettings.speed
+	 * @property {string} link.adminSettings.duplex Duplex type, Half or Full. - enum { 'Full', 'Half' }
+	 * @property {object} link.operSettings Current active link settings
+	 * @property {boolean} link.operSettings.autoNegotiation Auto negotiation on/off.
+	 * @property {number} link.operSettings.speed
+	 * @property {string} link.operSettings.duplex Duplex type, Half or Full. - enum { 'Full', 'Half' }
+	 * @property {number} link.interfaceType Integer indicating interface type, for example: 6 is ethernet.
+	 * @property {object} [IPv4] IPv4 network interface configuration.
+	 * @property {boolean} IPv4.enabled Indicates whether or not IPv4 is enabled.
+	 * @property {object} IPv4.config IPv4 configuration.
+	 * @property {object} [IPv4.config.manual] List of manually added IPv4 addresses.
+	 * @property {string} IPv4.config.manual.address IPv4 address.
+	 * @property {number} IPv4.config.manual.prefixLength Prefix/submask length.
+	 * @property {object} [IPv4.config.linkLocal] List of manually added IPv4 addresses.
+	 * @property {string} IPv4.config.linkLocal.address IPv4 address.
+	 * @property {number} IPv4.config.linkLocal.prefixLength Prefix/submask length.
+	 * @property {object} [IPv4.config.fromDHCP] IPv4 address configured by using DHCP.
+	 * @property {string} IPv4.config.fromDHCP.address IPv4 address.
+	 * @property {number} IPv4.config.fromDHCP.prefixLength Prefix/submask length.
+	 * @property {boolean} DHCP Indicates whether or not DHCP is used.
+	 * @property {object} [IPv6] IPv6 network interface configuration.
+	 * @property {boolean} IPv6.enabled Indicates whether or not IPv6 is enabled.
+	 * @property {object} IPv6.config  IPv6 configuration.
+	 * @property {boolean} [IPv6.config.acceptRouterAdvert] Indicates whether router advertisment is used.
+	 * @property {string} IPv6.config.DHCP DHCP configuration. - enum { 'Auto', 'Stateful', 'Stateless', 'Off' }
+	 * @property {object} [IPv6.config.manual] List of manually added IPv6 addresses.
+	 * @property {string} IPv6.config.manual.address IPv6 address.
+	 * @property {number} IPv6.config.manual.prefixLength Prefix/submask length.
+	 * @property {object} [IPv6.config.linkLocal] List of link local IPv6 addresses.
+	 * @property {string} IPv6.config.linkLocal.address IPv6 address.
+	 * @property {number} IPv6.config.linkLocal.prefixLength Prefix/submask length.
+	 * @property {object} [IPv6.config.fromDHCP] List of IPv6 addresses configured by using DHCP.
+	 * @property {string} IPv6.config.fromDHCP.address IPv6 address.
+	 * @property {number} IPv6.config.fromDHCP.prefixLength Prefix/submask length.
+	 * @property {object} [IPv6.config.fromRA] List of IPv6 addresses configured by using router advertisment.
+	 * @property {string} IPv6.config.fromRA.address IPv6 address.
+	 * @property {number} IPv6.config.fromRA.prefixLength Prefix/submask length.
+	 * @property {object} [IPv6.config.extension] Extension
+	 * @property {object} [extension] Extension
+	 * @property {string} extension.interfaceType
+	 * @property {object} [extension.dot3] Extension point prepared for future 802.3 configuration.
+	 * @property {object} [extension.dot11]
+	 * @property {string} extension.dot11.SSID
+	 * @property {string} extension.dot11.mode - enum { 'Ad-hoc', 'Infrastructure', 'Extended' }
+	 * @property {string} extension.dot11.alias
+	 * @property {string} extension.dot11.priority
+	 * @property {object} extension.dot11.security
+	 * @property {string} extension.dot11.security.mode  - enum { 'None', 'WEP', 'PSK', 'Dot1X', 'Extended'
+	 * @property {string} extension.dot11.security.algorithm - enum { 'CCMP', 'TKIP', 'Any', 'Extended' }
+	 * @property {object} extension.dot11.security.PSK
+	 * @property {string} extension.dot11.security.PSK.key According to IEEE802.11-2007 H.4.1 the RSNA PSK consists of 256 bits, or 64 octets when represented in hex
+	 *						Either Key or Passphrase shall be given, if both are supplied Key shall be used by the device and Passphrase ignored.
+	* @property {string} extension.dot11.security.PSK.passphrase According to IEEE802.11-2007 H.4.1 a pass-phrase is a sequence of between 8 and 63 ASCII-encoded characters and each character in the pass-phrase must have an encoding in the range of 32 to 126 (decimal),inclusive.
+	*											 if only Passpharse is supplied the Key shall be derived using the algorithm described in IEEE802.11-2007 section H.4
+	* @property {object} [extension.dot11.security.PSK.extension]
+	* @property {string} [extension.dot11.security.dot1X]
+	* @property {object} [extension.dot11.security.extension]
+	* @property {object} [extension.extension]
+	*/
 
-/**
- * @typedef {object} Cam~NetworkInterface
- * @property {string} token Unique identifier referencing the physical entity.
- * @property {boolean} enabled Indicates whether or not an interface is enabled.
- * @property {object} [info] network interface information
- * @property {string} info.name Network interface name, for example eth0
- * @property {string} info.hwAddress Network interface MAC address
- * @property {number} info.MTU Maximum transmission unit.
- * @property {object} [link] Link configuration.
- * @property {object} link.adminSettings Configured link settings.
- * @property {boolean} link.adminSettings.autoNegotiation Auto negotiation on/off.
- * @property {number} link.adminSettings.speed
- * @property {string} link.adminSettings.duplex Duplex type, Half or Full. - enum { 'Full', 'Half' }
- * @property {object} link.operSettings Current active link settings
- * @property {boolean} link.operSettings.autoNegotiation Auto negotiation on/off.
- * @property {number} link.operSettings.speed
- * @property {string} link.operSettings.duplex Duplex type, Half or Full. - enum { 'Full', 'Half' }
- * @property {number} link.interfaceType Integer indicating interface type, for example: 6 is ethernet.
- * @property {object} [IPv4] IPv4 network interface configuration.
- * @property {boolean} IPv4.enabled Indicates whether or not IPv4 is enabled.
- * @property {object} IPv4.config IPv4 configuration.
- * @property {object} [IPv4.config.manual] List of manually added IPv4 addresses.
- * @property {string} IPv4.config.manual.address IPv4 address.
- * @property {number} IPv4.config.manual.prefixLength Prefix/submask length.
- * @property {object} [IPv4.config.linkLocal] List of manually added IPv4 addresses.
- * @property {string} IPv4.config.linkLocal.address IPv4 address.
- * @property {number} IPv4.config.linkLocal.prefixLength Prefix/submask length.
- * @property {object} [IPv4.config.fromDHCP] IPv4 address configured by using DHCP.
- * @property {string} IPv4.config.fromDHCP.address IPv4 address.
- * @property {number} IPv4.config.fromDHCP.prefixLength Prefix/submask length.
- * @property {boolean} DHCP Indicates whether or not DHCP is used.
- * @property {object} [IPv6] IPv6 network interface configuration.
- * @property {boolean} IPv6.enabled Indicates whether or not IPv6 is enabled.
- * @property {object} IPv6.config  IPv6 configuration.
- * @property {boolean} [IPv6.config.acceptRouterAdvert] Indicates whether router advertisment is used.
- * @property {string} IPv6.config.DHCP DHCP configuration. - enum { 'Auto', 'Stateful', 'Stateless', 'Off' }
- * @property {object} [IPv6.config.manual] List of manually added IPv6 addresses.
- * @property {string} IPv6.config.manual.address IPv6 address.
- * @property {number} IPv6.config.manual.prefixLength Prefix/submask length.
- * @property {object} [IPv6.config.linkLocal] List of link local IPv6 addresses.
- * @property {string} IPv6.config.linkLocal.address IPv6 address.
- * @property {number} IPv6.config.linkLocal.prefixLength Prefix/submask length.
- * @property {object} [IPv6.config.fromDHCP] List of IPv6 addresses configured by using DHCP.
- * @property {string} IPv6.config.fromDHCP.address IPv6 address.
- * @property {number} IPv6.config.fromDHCP.prefixLength Prefix/submask length.
- * @property {object} [IPv6.config.fromRA] List of IPv6 addresses configured by using router advertisment.
- * @property {string} IPv6.config.fromRA.address IPv6 address.
- * @property {number} IPv6.config.fromRA.prefixLength Prefix/submask length.
- * @property {object} [IPv6.config.extension] Extension
- * @property {object} [extension] Extension
- * @property {string} extension.interfaceType
- * @property {object} [extension.dot3] Extension point prepared for future 802.3 configuration.
- * @property {object} [extension.dot11]
- * @property {string} extension.dot11.SSID
- * @property {string} extension.dot11.mode - enum { 'Ad-hoc', 'Infrastructure', 'Extended' }
- * @property {string} extension.dot11.alias
- * @property {string} extension.dot11.priority
- * @property {object} extension.dot11.security
- * @property {string} extension.dot11.security.mode  - enum { 'None', 'WEP', 'PSK', 'Dot1X', 'Extended'
- * @property {string} extension.dot11.security.algorithm - enum { 'CCMP', 'TKIP', 'Any', 'Extended' }
- * @property {object} extension.dot11.security.PSK
- * @property {string} extension.dot11.security.PSK.key According to IEEE802.11-2007 H.4.1 the RSNA PSK consists of 256 bits, or 64 octets when represented in hex
- *						Either Key or Passphrase shall be given, if both are supplied Key shall be used by the device and Passphrase ignored.
- * @property {string} extension.dot11.security.PSK.passphrase According to IEEE802.11-2007 H.4.1 a pass-phrase is a sequence of between 8 and 63 ASCII-encoded characters and each character in the pass-phrase must have an encoding in the range of 32 to 126 (decimal),inclusive.
- *											 if only Passpharse is supplied the Key shall be derived using the algorithm described in IEEE802.11-2007 section H.4
- * @property {object} [extension.dot11.security.PSK.extension]
- * @property {string} [extension.dot11.security.dot1X]
- * @property {object} [extension.dot11.security.extension]
- * @property {object} [extension.extension]
- */
+	/**
+	 * @callback Cam~GetNetworkInterfacesCallback
+	 * @property {?Error} error
+	 * @property {Array.<Cam~NetworkInterface>} network interfaces information
+	 * @property {string} xml Raw SOAP response
+	 */
 
-/**
- * @callback Cam~GetNetworkInterfacesCallback
- * @property {?Error} error
- * @property {Array.<Cam~NetworkInterface>} network interfaces information
- * @property {string} xml Raw SOAP response
- */
+	/**
+	 * Receive network interfaces information
+	 * @param {Cam~GetNetworkInterfacesCallback} [callback]
+	 */
+	Cam.prototype.getNetworkInterfaces = function(callback) {
+		this._request({
+			service: 'device'
+			, body: this._envelopeHeader() +
+			'<GetNetworkInterfaces xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				this.networkInterfaces = linerase(data).getNetworkInterfacesResponse;
+			}
+			if (callback) {
+				callback.call(this, err, this.networkInterfaces, xml);
+			}
+		}.bind(this));
+	};
 
-/**
- * Receive network interfaces information
- * @param {Cam~GetNetworkInterfacesCallback} [callback]
- */
-Cam.prototype.getNetworkInterfaces = function(callback) {
-	this._request({
-		service: 'device'
-		, body: this._envelopeHeader() +
-		'<GetNetworkInterfaces xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			this.networkInterfaces = linerase(data).getNetworkInterfacesResponse;
-		}
-		if (callback) {
-			callback.call(this, err, this.networkInterfaces, xml);
-		}
-	}.bind(this));
-};
+	/**
+	 * @typedef {object} Cam~NetworkProtocol
+	 * @property {string} name Network protocol type string. - enum { 'HTTP', 'HTTPS', 'RTSP' }
+	 * @property {boolean} enabled Indicates if the protocol is enabled or not.
+	 * @property {number} port The port that is used by the protocol.
+	 * @property {object} extension
+	 */
 
-/**
- * @typedef {object} Cam~NetworkProtocol
- * @property {string} name Network protocol type string. - enum { 'HTTP', 'HTTPS', 'RTSP' }
- * @property {boolean} enabled Indicates if the protocol is enabled or not.
- * @property {number} port The port that is used by the protocol.
- * @property {object} extension
- */
+	/**
+	 * @callback Cam~GetNetworkProtocolsCallback
+	 * @property {?Error} error
+	 * @property {Array.<Cam~NetworkProtocol>} network protocols information
+	 * @property {string} xml Raw SOAP response
+	 */
 
-/**
- * @callback Cam~GetNetworkProtocolsCallback
- * @property {?Error} error
- * @property {Array.<Cam~NetworkProtocol>} network protocols information
- * @property {string} xml Raw SOAP response
- */
+	/**
+	 * Receive network protocols information
+	 * @param {Cam~GetNetworkProtocolsCallback} [callback]
+	 */
 
-/**
- * Receive network protocols information
- * @param {Cam~GetNetworkProtocolsCallback} [callback]
- */
-
-Cam.prototype.getNetworkProtocols = function(callback) {
-	this._request({
-		service: 'device'
-		, body: this._envelopeHeader() +
-		'<GetNetworkProtocols xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			this.networkProtocols = linerase(data).getNetworkProtocolsResponse;
-		}
-		if (callback) {
-			callback.call(this, err, this.networkProtocols, xml);
-		}
-	}.bind(this));
-};
+	Cam.prototype.getNetworkProtocols = function(callback) {
+		this._request({
+			service: 'device'
+			, body: this._envelopeHeader() +
+			'<GetNetworkProtocols xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				this.networkProtocols = linerase(data).getNetworkProtocolsResponse;
+			}
+			if (callback) {
+				callback.call(this, err, this.networkProtocols, xml);
+			}
+		}.bind(this));
+	};
+}

--- a/lib/events.js
+++ b/lib/events.js
@@ -4,219 +4,219 @@
  * @author Andrew D.Laptev <a.d.laptev@gmail.com>
  * @licence MIT
  */
+module.exports = (Cam) => {
 
-/**
- * @typedef {object} Cam~CreatePullPointSubscriptionResponse
- * @property {object} subscriptionReference
- * @property {string|object} subscriptionReference.address
- * @property {Date} currentTime
- * @property {Date} terminationTime
- */
+	/**
+	 * @typedef {object} Cam~CreatePullPointSubscriptionResponse
+	 * @property {object} subscriptionReference
+	 * @property {string|object} subscriptionReference.address
+	 * @property {Date} currentTime
+	 * @property {Date} terminationTime
+	 */
 
-/**
- * Events namespace for the device, stores all information about device events
- * @name Cam#events
- * @type object
- * @property {Cam~EventProperties} properties
- * @property {Cam~CreatePullPointSubscriptionResponse} subscription
- * @property {Date} terminationTime Time when pull-point subscription is over
- * @property {number} messageLimit Pull message count
- */
+	/**
+	 * Events namespace for the device, stores all information about device events
+	 * @name Cam#events
+	 * @type object
+	 * @property {Cam~EventProperties} properties
+	 * @property {Cam~CreatePullPointSubscriptionResponse} subscription
+	 * @property {Date} terminationTime Time when pull-point subscription is over
+	 * @property {number} messageLimit Pull message count
+	 */
 
-const Cam = require('./cam').Cam
-	, cam = require('./cam')
-	, linerase = require('./utils').linerase
-	, url = require('url')
-	;
+	const linerase = require('./utils').linerase
+		, url = require('url')
+		;
 
-/**
- * Event properties object
- * @typedef {object} Cam~EventProperties
- * @property {array} topicNamespaceLocation
- * @property {object} topicSet
- * @property {array} topicExpressionDialect
- */
+	/**
+	 * Event properties object
+	 * @typedef {object} Cam~EventProperties
+	 * @property {array} topicNamespaceLocation
+	 * @property {object} topicSet
+	 * @property {array} topicExpressionDialect
+	 */
 
-/**
- * @callback Cam~GetEventPropertiesCallback
- * @property {?Error} err
- * @property {Cam~EventProperties} response
- * @property {string} response xml
- */
+	/**
+	 * @callback Cam~GetEventPropertiesCallback
+	 * @property {?Error} err
+	 * @property {Cam~EventProperties} response
+	 * @property {string} response xml
+	 */
 
-/**
- * Get event properties of the device. Sets `events` property of the device
- * @param {Cam~GetEventPropertiesCallback} callback
- */
-Cam.prototype.getEventProperties = function(callback) {
-	this._request({
-		service: 'events'
-		, body: this._envelopeHeader() +
-		'<GetEventProperties xmlns="http://www.onvif.org/ver10/events/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, res, xml) {
-		if (!err) {
-			this.events.properties = linerase(res).getEventPropertiesResponse;
-		}
-		callback.call(this, err, err ? null : this.events.properties, xml);
-	}.bind(this));
-};
-
-/**
- * Get event service capabilities
- * @param {function} callback
- */
-Cam.prototype.getEventServiceCapabilities = function(callback) {
-	this._request({
-		service: 'events'
-		, body: this._envelopeHeader() +
-		'<GetServiceCapabilities xmlns="http://www.onvif.org/ver10/events/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, res, xml) {
-		if (!err) {
-			var data = linerase(res[0].getServiceCapabilitiesResponse[0].capabilities[0].$);
-		}
-		callback.call(this, err, data, xml);
-	}.bind(this));
-};
-
-/**
- * Create pull-point subscription
- * @param {function} callback
- */
-Cam.prototype.createPullPointSubscription = function(callback) {
-	this._request({
-		service: 'events'
-		, body: this._envelopeHeader() +
-		'<CreatePullPointSubscription xmlns="http://www.onvif.org/ver10/events/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, res, xml) {
-		if (!err) {
-			this.events.subscription = linerase(res[0].createPullPointSubscriptionResponse[0]);
-			this.events.subscription.subscriptionReference.address =
-				this._parseUrl(this.events.subscription.subscriptionReference.address);
-			this.events.terminationTime = _terminationTime(this.events.subscription);
-		}
-		callback.call(this, err, err ? null : this.events.subscription, xml);
-	}.bind(this));
-};
-
-/**
- * @typedef {object} Cam~Event
- * @property {Date} currentTime
- * @property {Date} terminationTime
- * @property {Cam~NotificationMessage|Array.<Cam~NotificationMessage>} [notificationMessage]
- */
-
-/**
- * @typedef {object} Cam~NotificationMessage
- * @property {string} subscriptionReference.address Pull-point address
- * @property {string} topic._ Namespace of message topic
- * @property {object} message Message object
- */
-
-/**
- * @callback Cam~PullMessagesResponse
- * @property {?Error} error
- * @property {Cam~Event} response Message
- * @property {string} xml Raw SOAP response
- */
-
-/**
- * Pull messages from pull-point subscription
- * @param options
- * @param {number} [options.timeout=30000]
- * @param {number} [options.messageLimit=1]
- * @param {Cam~PullMessagesResponse} callback
- * @throws {Error} {@link Cam#events.subscription} must exists
- */
-Cam.prototype.pullMessages = function(options, callback) {
-	try {
-		var urlAddress = this.events.subscription.subscriptionReference.address;
-	} catch (e) {
-		throw new Error('You should create pull-point subscription first!');
-	}
-	this._request({
-		url: urlAddress
-		, body: this._envelopeHeader() +
-		'<PullMessages xmlns="http://www.onvif.org/ver10/events/wsdl">' +
-			'<Timeout>PT' + ((options.timeout || 30000) / 1000) + 'S</Timeout>' +
-			'<MessageLimit>' + (options.messageLimit || 1) + '</MessageLimit>' +
-		'</PullMessages>' +
-		this._envelopeFooter()
-	}, function(err, res, xml) {
-		if (!err) {
-			var data = linerase(res).pullMessagesResponse;
-		}
-		callback.call(this, err, data, xml);
-	}.bind(this));
-};
-
-/**
- * Count time before pull-point subscription terminates
- * @param {Cam~CreatePullPointSubscriptionResponse} response
- * @returns {Date}
- * @private
- */
-function _terminationTime(response) {
-	return new Date(Date.now() - response.currentTime.getTime() + response.terminationTime.getTime());
-}
-
-/**
- * Bind event handling to the `event` event
- */
-Cam.prototype.on('newListener', function(name) {
-	// if there is the first listener, start pulling
-	if (name === 'event' && this.listeners(name).length === 0) {
-		this._eventRequest();
-	}
-});
-
-/**
- * Event loop for pullMessages request
- * @private
- */
-Cam.prototype._eventRequest = function() {
-	this.events.timeout = this.events.timeout || 30000; // setting timeout
-	this.events.messageLimit = this.events.messageLimit || 1; // setting message limit
-	if (!this.events.terminationTime || (this.events.terminationTime < Date.now() + this.events.timeout)) {
-		// if there is no pull-point subscription or it will be dead soon, create new
-		this.createPullPointSubscription(this._eventPull.bind(this));
-	} else {
-		this._eventPull();
-	}
-};
-
-/**
- * Event loop for pullMessages request
- * @private
- */
-Cam.prototype._eventPull = function() {
-	if (this.listeners('event').length) { // check for event listeners, if zero, stop pulling
-		this.pullMessages({
-			timeout: this.events.timeout
-			, messageLimit: this.events.messageLimit
-		}, function(err, data) {
+	/**
+	 * Get event properties of the device. Sets `events` property of the device
+	 * @param {Cam~GetEventPropertiesCallback} callback
+	 */
+	Cam.prototype.getEventProperties = function(callback) {
+		this._request({
+			service: 'events'
+			, body: this._envelopeHeader() +
+			'<GetEventProperties xmlns="http://www.onvif.org/ver10/events/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, res, xml) {
 			if (!err) {
-				if (data.notificationMessage) {
-					if (!Array.isArray(data.notificationMessage)) {
-						data.notificationMessage = [data.notificationMessage];
-					}
-					data.notificationMessage.forEach(function(message) {
-						// pull-point address check
-						if (message.subscriptionReference.address === this.events.subscription.subscriptionReference.address.href) {
-							/**
-							 * Indicates message from device.
-							 * @event Cam#event
-							 * @type {Cam~NotificationMessage}
-							 */
-							this.emit('event', message);
-						}
-					}.bind(this));
-				}
-				this.events.terminationTime = _terminationTime(data);
+				this.events.properties = linerase(res).getEventPropertiesResponse;
 			}
-			this._eventRequest();
+			callback.call(this, err, err ? null : this.events.properties, xml);
 		}.bind(this));
+	};
+
+	/**
+	 * Get event service capabilities
+	 * @param {function} callback
+	 */
+	Cam.prototype.getEventServiceCapabilities = function(callback) {
+		this._request({
+			service: 'events'
+			, body: this._envelopeHeader() +
+			'<GetServiceCapabilities xmlns="http://www.onvif.org/ver10/events/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, res, xml) {
+			if (!err) {
+				var data = linerase(res[0].getServiceCapabilitiesResponse[0].capabilities[0].$);
+			}
+			callback.call(this, err, data, xml);
+		}.bind(this));
+	};
+
+	/**
+	 * Create pull-point subscription
+	 * @param {function} callback
+	 */
+	Cam.prototype.createPullPointSubscription = function(callback) {
+		this._request({
+			service: 'events'
+			, body: this._envelopeHeader() +
+			'<CreatePullPointSubscription xmlns="http://www.onvif.org/ver10/events/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, res, xml) {
+			if (!err) {
+				this.events.subscription = linerase(res[0].createPullPointSubscriptionResponse[0]);
+				this.events.subscription.subscriptionReference.address =
+					this._parseUrl(this.events.subscription.subscriptionReference.address);
+				this.events.terminationTime = _terminationTime(this.events.subscription);
+			}
+			callback.call(this, err, err ? null : this.events.subscription, xml);
+		}.bind(this));
+	};
+
+	/**
+	 * @typedef {object} Cam~Event
+	 * @property {Date} currentTime
+	 * @property {Date} terminationTime
+	 * @property {Cam~NotificationMessage|Array.<Cam~NotificationMessage>} [notificationMessage]
+	 */
+
+	/**
+	 * @typedef {object} Cam~NotificationMessage
+	 * @property {string} subscriptionReference.address Pull-point address
+	 * @property {string} topic._ Namespace of message topic
+	 * @property {object} message Message object
+	 */
+
+	/**
+	 * @callback Cam~PullMessagesResponse
+	 * @property {?Error} error
+	 * @property {Cam~Event} response Message
+	 * @property {string} xml Raw SOAP response
+	 */
+
+	/**
+	 * Pull messages from pull-point subscription
+	 * @param options
+	 * @param {number} [options.timeout=30000]
+	 * @param {number} [options.messageLimit=1]
+	 * @param {Cam~PullMessagesResponse} callback
+	 * @throws {Error} {@link Cam#events.subscription} must exists
+	 */
+	Cam.prototype.pullMessages = function(options, callback) {
+		try {
+			var urlAddress = this.events.subscription.subscriptionReference.address;
+		} catch (e) {
+			throw new Error('You should create pull-point subscription first!');
+		}
+		this._request({
+			url: urlAddress
+			, body: this._envelopeHeader() +
+			'<PullMessages xmlns="http://www.onvif.org/ver10/events/wsdl">' +
+				'<Timeout>PT' + ((options.timeout || 30000) / 1000) + 'S</Timeout>' +
+				'<MessageLimit>' + (options.messageLimit || 1) + '</MessageLimit>' +
+			'</PullMessages>' +
+			this._envelopeFooter()
+		}, function(err, res, xml) {
+			if (!err) {
+				var data = linerase(res).pullMessagesResponse;
+			}
+			callback.call(this, err, data, xml);
+		}.bind(this));
+	};
+
+	/**
+	 * Count time before pull-point subscription terminates
+	 * @param {Cam~CreatePullPointSubscriptionResponse} response
+	 * @returns {Date}
+	 * @private
+	 */
+	function _terminationTime(response) {
+		return new Date(Date.now() - response.currentTime.getTime() + response.terminationTime.getTime());
 	}
-};
+
+	/**
+	 * Bind event handling to the `event` event
+	 */
+	Cam.prototype.on('newListener', function(name) {
+		// if there is the first listener, start pulling
+		if (name === 'event' && this.listeners(name).length === 0) {
+			this._eventRequest();
+		}
+	});
+
+	/**
+	 * Event loop for pullMessages request
+	 * @private
+	 */
+	Cam.prototype._eventRequest = function() {
+		this.events.timeout = this.events.timeout || 30000; // setting timeout
+		this.events.messageLimit = this.events.messageLimit || 1; // setting message limit
+		if (!this.events.terminationTime || (this.events.terminationTime < Date.now() + this.events.timeout)) {
+			// if there is no pull-point subscription or it will be dead soon, create new
+			this.createPullPointSubscription(this._eventPull.bind(this));
+		} else {
+			this._eventPull();
+		}
+	};
+
+	/**
+	 * Event loop for pullMessages request
+	 * @private
+	 */
+	Cam.prototype._eventPull = function() {
+		if (this.listeners('event').length) { // check for event listeners, if zero, stop pulling
+			this.pullMessages({
+				timeout: this.events.timeout
+				, messageLimit: this.events.messageLimit
+			}, function(err, data) {
+				if (!err) {
+					if (data.notificationMessage) {
+						if (!Array.isArray(data.notificationMessage)) {
+							data.notificationMessage = [data.notificationMessage];
+						}
+						data.notificationMessage.forEach(function(message) {
+							// pull-point address check
+							if (message.subscriptionReference.address === this.events.subscription.subscriptionReference.address.href) {
+								/**
+								 * Indicates message from device.
+								 * @event Cam#event
+								 * @type {Cam~NotificationMessage}
+								 */
+								this.emit('event', message);
+							}
+						}.bind(this));
+					}
+					this.events.terminationTime = _terminationTime(data);
+				}
+				this._eventRequest();
+			}.bind(this));
+		}
+	}
+}

--- a/lib/imaging.js
+++ b/lib/imaging.js
@@ -4,215 +4,215 @@
  * @author Andrew D.Laptev <a.d.laptev@gmail.com>
  * @licence MIT
  */
+module.exports = (Cam) => {
 
-const Cam = require('./cam').Cam
-	, linerase = require('./utils').linerase
-	;
+	const linerase = require('./utils').linerase;
 
-/**
- * @typedef {object} Cam~ImagingSettings
- * @property {number} brightness
- * @property {number} colorSaturation
- * @property {object} focus
- * @property {string} focus.autoFocusMode
- * @property {number} sharpness
- */
+	/**
+	 * @typedef {object} Cam~ImagingSettings
+	 * @property {number} brightness
+	 * @property {number} colorSaturation
+	 * @property {object} focus
+	 * @property {string} focus.autoFocusMode
+	 * @property {number} sharpness
+	 */
 
-/**
- * @callback Cam~GetImagingSettingsCallback
- * @property {?Error} error
- * @property {Cam~ImagingSettings} status
- */
+	/**
+	 * @callback Cam~GetImagingSettingsCallback
+	 * @property {?Error} error
+	 * @property {Cam~ImagingSettings} status
+	 */
 
-/**
- * Get the ImagingConfiguration for the requested VideoSource (default - the activeSource)
- * @param {object} [options]
- * @param {string} [options.token] {@link Cam#activeSource.profileToken}
- * @param {Cam~GetImagingSettingsCallback} callback
- */
-Cam.prototype.getImagingSettings = function(options, callback) {
-	if (typeof callback === 'undefined') {
-		callback = options;
-		options = {};
-	}
-	this._request({
-		service: 'imaging'
-		, body: this._envelopeHeader() +
-		'<GetImagingSettings xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
-			'<VideoSourceToken  xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' + ( options.token || this.activeSource.sourceToken ) + '</VideoSourceToken>' +
-		'</GetImagingSettings>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) { 
-			callback.call(this, err, err ? null : linerase(data).getImagingSettingsResponse.imagingSettings, xml);
+	/**
+	 * Get the ImagingConfiguration for the requested VideoSource (default - the activeSource)
+	 * @param {object} [options]
+	 * @param {string} [options.token] {@link Cam#activeSource.profileToken}
+	 * @param {Cam~GetImagingSettingsCallback} callback
+	 */
+	Cam.prototype.getImagingSettings = function(options, callback) {
+		if (typeof callback === 'undefined') {
+			callback = options;
+			options = {};
 		}
-	}.bind(this));
-};
+		this._request({
+			service: 'imaging'
+			, body: this._envelopeHeader() +
+			'<GetImagingSettings xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
+				'<VideoSourceToken  xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' + ( options.token || this.activeSource.sourceToken ) + '</VideoSourceToken>' +
+			'</GetImagingSettings>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) { 
+				callback.call(this, err, err ? null : linerase(data).getImagingSettingsResponse.imagingSettings, xml);
+			}
+		}.bind(this));
+	};
 
-/**
- * @typedef {object} Cam~ImagingSetting
- * @property {string} token Video source token
- * @property {number} brightness
- * @property {number} colorSaturation
- * @property {number} contrast
- * @property {number} sharpness
- */
+	/**
+	 * @typedef {object} Cam~ImagingSetting
+	 * @property {string} token Video source token
+	 * @property {number} brightness
+	 * @property {number} colorSaturation
+	 * @property {number} contrast
+	 * @property {number} sharpness
+	 */
 
-/**
- * Set the ImagingConfiguration for the requested VideoSource (default - the activeSource)
- * @param {Cam~ImagingSetting} options
- * @param callback
- */
-Cam.prototype.setImagingSettings = function(options, callback) {
-	this._request({
-		service: 'imaging'
-		, body: this._envelopeHeader() +
-		'<SetImagingSettings xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
-			'<VideoSourceToken  xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
-				( options.token || this.activeSource.sourceToken) +
-			'</VideoSourceToken>' +
- 
-			'<ImagingSettings xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
-				( 
-					options.brightness ? 
-					(
-						'<Brightness xmlns="http://www.onvif.org/ver10/schema">' +
-							options.brightness +
-						'</Brightness>' 
-					) : ''
-				)
+	/**
+	 * Set the ImagingConfiguration for the requested VideoSource (default - the activeSource)
+	 * @param {Cam~ImagingSetting} options
+	 * @param callback
+	 */
+	Cam.prototype.setImagingSettings = function(options, callback) {
+		this._request({
+			service: 'imaging'
+			, body: this._envelopeHeader() +
+			'<SetImagingSettings xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
+				'<VideoSourceToken  xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
+					( options.token || this.activeSource.sourceToken) +
+				'</VideoSourceToken>' +
+	
+				'<ImagingSettings xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
+					( 
+						options.brightness ? 
+						(
+							'<Brightness xmlns="http://www.onvif.org/ver10/schema">' +
+								options.brightness +
+							'</Brightness>' 
+						) : ''
+					)
 
-			+
+				+
 
-				( 
-					options.colorSaturation ? 
-					(
-						'<ColorSaturation xmlns="http://www.onvif.org/ver10/schema">' +
-							options.colorSaturation +
-						'</ColorSaturation>' 
-					) : ''
-				)
+					( 
+						options.colorSaturation ? 
+						(
+							'<ColorSaturation xmlns="http://www.onvif.org/ver10/schema">' +
+								options.colorSaturation +
+							'</ColorSaturation>' 
+						) : ''
+					)
 
-			+
+				+
 
-				( 
-					options.contrast ? 
-					(
-						'<Contrast xmlns="http://www.onvif.org/ver10/schema">' +
-							options.contrast +
-						'</Contrast>' 
-					) : ''
-				)
+					( 
+						options.contrast ? 
+						(
+							'<Contrast xmlns="http://www.onvif.org/ver10/schema">' +
+								options.contrast +
+							'</Contrast>' 
+						) : ''
+					)
 
-			+
+				+
 
-				( 
-					options.sharpness ? 
-					(
-						'<Sharpness xmlns="http://www.onvif.org/ver10/schema">' +
-							options.sharpness +
-						'</Sharpness>' 
-					) : ''
-				)
+					( 
+						options.sharpness ? 
+						(
+							'<Sharpness xmlns="http://www.onvif.org/ver10/schema">' +
+								options.sharpness +
+							'</Sharpness>' 
+						) : ''
+					)
 
-			+
-			'</ImagingSettings>' +
-		'</SetImagingSettings>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) { 
-			callback.call(this, err, err ? null : linerase(data).setImagingSettingsResponse, xml);
+				+
+				'</ImagingSettings>' +
+			'</SetImagingSettings>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) { 
+				callback.call(this, err, err ? null : linerase(data).setImagingSettingsResponse, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * @typedef {object} Cam~ImagingServiceCapabilities
+	 * @property {boolean} ImageStabilization Indicates whether or not Image Stabilization feature is supported
+	 * @property {boolean} [Presets] Indicates whether or not Imaging Presets feature is supported
+	 */
+
+	/**
+	 * @callback Cam~GetImagingServiceCapabilitiesCallback
+	 * @property {?Error} error
+	 * @property {Cam~ImagingServiceCapabilities} capabilities
+	 */
+
+	/**
+	 * Returns the capabilities of the imaging service
+	 * @property {Cam~GetImagingServiceCapabilitiesCallback}
+	 */
+	Cam.prototype.getImagingServiceCapabilities = function(callback) {
+		this._request({
+			service: 'imaging'
+			, body: this._envelopeHeader() +
+			'<GetServiceCapabilities xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
+			'</GetServiceCapabilities>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data[0].getServiceCapabilitiesResponse[0].capabilities[0].$), xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * @typedef {object} Cam~ImagingPreset
+	 * @property {string} token
+	 * @property {string} type Indicates Imaging Preset Type
+	 * @property {string} Name Human readable name of the Imaging Preset
+	 */
+
+	/**
+	 * @callback Cam~GetCurrentImagingPresetCallback
+	 * @property {?Error} error
+	 * @property {Cam~ImagingPreset} preset
+	 */
+
+	/**
+	 * Get the last Imaging Preset applied
+	 * @param {object} [options]
+	 * @param {string} [options.token] Reference token to the VideoSource where the current Imaging Preset should be requested
+	 * @param {Cam~GetCurrentImagingPresetCallback} callback
+	 */
+	Cam.prototype.getCurrentImagingPreset = function(options, callback) {
+		if (typeof callback === 'undefined') {
+			callback = options;
+			options = {};
 		}
-	}.bind(this));
-};
+		this._request({
+			service: 'imaging'
+			, body: this._envelopeHeader() +
+			'<GetCurrentPreset xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
+				'<VideoSourceToken>' + ( options.token || this.activeSource.sourceToken ) + '</VideoSourceToken>' +
+			'</GetCurrentPreset>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data).getCurrentPresetResponse.preset, xml);
+			}
+		}.bind(this));
+	};
 
-/**
- * @typedef {object} Cam~ImagingServiceCapabilities
- * @property {boolean} ImageStabilization Indicates whether or not Image Stabilization feature is supported
- * @property {boolean} [Presets] Indicates whether or not Imaging Presets feature is supported
- */
-
-/**
- * @callback Cam~GetImagingServiceCapabilitiesCallback
- * @property {?Error} error
- * @property {Cam~ImagingServiceCapabilities} capabilities
- */
-
-/**
- * Returns the capabilities of the imaging service
- * @property {Cam~GetImagingServiceCapabilitiesCallback}
- */
-Cam.prototype.getImagingServiceCapabilities = function(callback) {
-	this._request({
-		service: 'imaging'
-		, body: this._envelopeHeader() +
-		'<GetServiceCapabilities xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
-		'</GetServiceCapabilities>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) {
-			callback.call(this, err, err ? null : linerase(data[0].getServiceCapabilitiesResponse[0].capabilities[0].$), xml);
-		}
-	}.bind(this));
-};
-
-/**
- * @typedef {object} Cam~ImagingPreset
- * @property {string} token
- * @property {string} type Indicates Imaging Preset Type
- * @property {string} Name Human readable name of the Imaging Preset
- */
-
-/**
- * @callback Cam~GetCurrentImagingPresetCallback
- * @property {?Error} error
- * @property {Cam~ImagingPreset} preset
- */
-
-/**
- * Get the last Imaging Preset applied
- * @param {object} [options]
- * @param {string} [options.token] Reference token to the VideoSource where the current Imaging Preset should be requested
- * @param {Cam~GetCurrentImagingPresetCallback} callback
- */
-Cam.prototype.getCurrentImagingPreset = function(options, callback) {
-	if (typeof callback === 'undefined') {
-		callback = options;
-		options = {};
-	}
-	this._request({
-		service: 'imaging'
-		, body: this._envelopeHeader() +
-		'<GetCurrentPreset xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
-			'<VideoSourceToken>' + ( options.token || this.activeSource.sourceToken ) + '</VideoSourceToken>' +
-		'</GetCurrentPreset>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) {
-			callback.call(this, err, err ? null : linerase(data).getCurrentPresetResponse.preset, xml);
-		}
-	}.bind(this));
-};
-
-/**
- * Set the ImagingConfiguration for the requested or current VideoSource
- * @param options
- * @param {string} [options.token] Reference token to the VideoSource to which the specified Imaging Preset should be applied.
- * @param {string} options.presetToken Reference token to the Imaging Preset to be applied to the specified Video Source
- * @param {Cam~RequestCallback} callback
- */
-Cam.prototype.setCurrentImagingPreset = function(options, callback) {
-	this._request({
-		service: 'imaging'
-		, body: this._envelopeHeader() +
-		'<SetCurrentPreset xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
-			'<VideoSourceToken>' + ( options.token || this.activeSource.sourceToken ) + '</VideoSourceToken>' +
-			'<PresetToken>' + options.presetToken + '</PresetToken>' +
-		'</SetCurrentPreset>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) {
-			callback.call(this, err, err ? null : linerase(data).setCurrentPresetResponse, xml);
-		}
-	}.bind(this));
-};
+	/**
+	 * Set the ImagingConfiguration for the requested or current VideoSource
+	 * @param options
+	 * @param {string} [options.token] Reference token to the VideoSource to which the specified Imaging Preset should be applied.
+	 * @param {string} options.presetToken Reference token to the Imaging Preset to be applied to the specified Video Source
+	 * @param {Cam~RequestCallback} callback
+	 */
+	Cam.prototype.setCurrentImagingPreset = function(options, callback) {
+		this._request({
+			service: 'imaging'
+			, body: this._envelopeHeader() +
+			'<SetCurrentPreset xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
+				'<VideoSourceToken>' + ( options.token || this.activeSource.sourceToken ) + '</VideoSourceToken>' +
+				'<PresetToken>' + options.presetToken + '</PresetToken>' +
+			'</SetCurrentPreset>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data).setCurrentPresetResponse, xml);
+			}
+		}.bind(this));
+	};
+}

--- a/lib/media.js
+++ b/lib/media.js
@@ -4,726 +4,726 @@
  * @author Andrew D.Laptev <a.d.laptev@gmail.com>
  * @licence MIT
  */
+module.exports = (Cam) => {
 
-const Cam = require('./cam').Cam
-	, linerase = require('./utils').linerase
-	;
+	const linerase = require('./utils').linerase;
 
-/**
- * @typedef {object} Cam~VideoSource
- * @property {string} $.token Video source token
- * @property {number} framerate
- * @property {number} resolution.width
- * @property {number} resolution.height
- */
+	/**
+	 * @typedef {object} Cam~VideoSource
+	 * @property {string} $.token Video source token
+	 * @property {number} framerate
+	 * @property {number} resolution.width
+	 * @property {number} resolution.height
+	 */
 
-/**
- * @callback Cam~GetVideoSourcesCallback
- * @property {?Error} error
- * @property {Cam~VideoSource|Array.<Cam~VideoSource>} videoSources
- * @property {string} xml Raw SOAP response
- */
+	/**
+	 * @callback Cam~GetVideoSourcesCallback
+	 * @property {?Error} error
+	 * @property {Cam~VideoSource|Array.<Cam~VideoSource>} videoSources
+	 * @property {string} xml Raw SOAP response
+	 */
 
-/**
- * Receive video sources
- * @param {Cam~GetVideoSourcesCallback} [callback]
- */
-Cam.prototype.getVideoSources = function(callback) {
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetVideoSources xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			/**
-			 * Video sources
-			 * @name Cam#videoSources
-			 * @type {Cam~VideoSource|Array.<Cam~VideoSource>}
-			 */
-			this.videoSources = linerase(data).getVideoSourcesResponse.videoSources;
+	/**
+	 * Receive video sources
+	 * @param {Cam~GetVideoSourcesCallback} [callback]
+	 */
+	Cam.prototype.getVideoSources = function(callback) {
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetVideoSources xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				/**
+				 * Video sources
+				 * @name Cam#videoSources
+				 * @type {Cam~VideoSource|Array.<Cam~VideoSource>}
+				 */
+				this.videoSources = linerase(data).getVideoSourcesResponse.videoSources;
+			}
+			if (callback) {
+				callback.call(this, err, this.videoSources, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * @typedef {object} Cam~VideoSourceConfiguration
+	 * @property {string} token Token that uniquely refernces this configuration
+	 * @property {string} sourceToken Reference to the physical input
+	 * @property {string} name User readable name
+	 * @property {number} useCount Number of internal references currently using this configuration
+	 * @property {object} bounds
+	 * @property {number} bounds.height
+	 * @property {number} bounds.width
+	 * @property {number} bounds.x
+	 * @property {number} bounds.y
+	 */
+
+	/**
+	 * @callback Cam~GetVideoSourceConfigurationsCallback
+	 * @property {?Error} error
+	 * @property {Array.<Cam~VideoSourceConfiguration>} videoSourceConfigurations
+	 * @property {string} xml Raw SOAP response
+	 */
+
+	/**
+	 * Receive video sources
+	 * @param {Cam~GetVideoSourceConfigurationsCallback} [callback]
+	 */
+	Cam.prototype.getVideoSourceConfigurations = function(callback) {
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetVideoSourceConfigurations xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				this.videoSourceConfigurations = data[0].getVideoSourceConfigurationsResponse[0].configurations.map(function(data) {
+					var obj =  linerase(data);
+					return {
+						token: obj.$.token
+						, name: obj.name
+						, useCount: obj.useCount
+						, sourceToken: obj.sourceToken
+						, bounds: {
+							height: obj.bounds.$.height
+							, width: obj.bounds.$.width
+							, x: obj.bounds.$.x
+							, y: obj.bounds.$.y
+						}
+					};
+				});
+			}
+			if (callback) {
+				callback.call(this, err, this.videoSourceConfigurations, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * @typedef {object} Cam~VideoEncoderConfiguration
+	 * @property {string} $.token Token that uniquely refernces this configuration
+	 * @property {string} name User readable name.
+	 * @property {string} useCount Number of internal references currently using this configuration
+	 * @property {string} encoding Used video codec ('JPEG' | 'MPEG4' | 'H264' )
+	 * @property {object} resolution Configured video resolution
+	 * @property {number} resolution.width
+	 * @property {number} resolution.height
+	 * @property {number} quality Relative value for the video quantizers and the quality of the video. A high value within supported quality range means higher quality
+	 * @property {object} [rateControl] Optional element to configure rate control related parameters
+	 * @property {number} rateControl.frameRateLimit
+	 * @property {number} rateControl.encodingInterval
+	 * @property {number} rateControl.bitrateLimit
+	 * @property {object} [H264] Optional element to configure H.264 related parameters
+	 * @property {number} H264.govLength Group of Video frames length
+	 * @property {string} H264.H264profile the H.264 profile
+	 * @property {object} [MPEG4] Optional element to configure Mpeg4 related parameters
+	 * @property {number} MPEG4.govLength Determines the interval in which the I-Frames will be coded.
+	 * @property {string} MPEG4.MPEG4profile the Mpeg4 profile
+	 * @property {object} multicast
+	 * @property {string} multicast.address.type
+	 * @property {string} [multicast.address.IPv4Address]
+	 * @property {string} [multicast.address.IPv6Address]
+	 * @property {number} multicast.port
+	 * @property {number} multicast.TTL
+	 * @property {boolean} multicast.autoStart
+	 * @property {string} sessionTimeout The rtsp session timeout for the related video stream
+	 */
+
+	/**
+	 * @callback Cam~VideoEncoderConfigurationCallback
+	 * @property {?Error} error
+	 * @property {Cam~VideoEncoderConfiguration} videoEncoderConfiguration
+	 * @property {string} xml Raw SOAP response
+	 */
+
+	/**
+	 * @callback Cam~VideoEncoderConfigurationsCallback
+	 * @property {?Error} error
+	 * @property {Array.<Cam~VideoEncoderConfiguration>} videoEncoderConfigurations
+	 * @property {string} xml Raw SOAP response
+	 */
+
+	/**
+	 * Get existing video encoder configuration by its token
+	 * If token is omitted tries first from #videoEncoderConfigurations array
+	 * @param {string} [token] Token of the requested video encoder configuration
+	 * @param {Cam~VideoEncoderConfigurationCallback} callback
+	 */
+	Cam.prototype.getVideoEncoderConfiguration = function(token, callback) {
+		if (callback === undefined) {
+			callback = token;
+			if (this.videoEncoderConfigurations && this.videoEncoderConfigurations[0]) {
+				token = this.videoEncoderConfigurations[0].$.token;
+			} else {
+				return callback(new Error('No video encoder configuration token is present!'));
+			}
 		}
-		if (callback) {
-			callback.call(this, err, this.videoSources, xml);
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetVideoEncoderConfiguration xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+				'<ConfigurationToken>' + token + '</ConfigurationToken>' +
+			'</GetVideoEncoderConfiguration>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data[0].getVideoEncoderConfigurationResponse[0].configuration), xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * @typedef {object} Cam~VideoEncoderConfigurationOptions
+	 * @property {object} qualityRange Range of the quality values. A high value means higher quality
+	 * @property {number} qualityRange.min
+	 * @property {number} qualityRange.max
+	 * @property {object} [JPEG] Optional JPEG encoder settings ranges
+	 * @property {object} JPEG.resolutionsAvailable List of supported resolutions
+	 * @property {number} JPEG.resolutionsAvailable.width
+	 * @property {number} JPEG.resolutionsAvailable.height
+	 * @property {object} JPEG.frameRateRange Range of frame rate settings
+	 * @property {number} JPEG.frameRateRange.min
+	 * @property {number} JPEG.frameRateRange.max
+	 * @property {object} JPEG.encodingIntervalRange Range of encoding interval settings
+	 * @property {number} JPEG.encodingInterval.min
+	 * @property {number} JPEG.encodingInterval.max
+	 * @property {object} [MPEG4] Optional MPEG4 encoder settings ranges
+	 * @property {object} MPEG4.resolutionsAvailable List of supported resolutions
+	 * @property {number} MPEG4.resolutionsAvailable.width
+	 * @property {number} MPEG4.resolutionsAvailable.height
+	 * @property {object} MPEG4.resolutionsAvailable List of supported resolutions
+	 * @property {object} MPEG4.frameRateRange Range of frame rate settings
+	 * @property {number} MPEG4.frameRateRange.min
+	 * @property {number} MPEG4.frameRateRange.max
+	 * @property {object} MPEG4.encodingIntervalRange Range of encoding interval settings
+	 * @property {number} MPEG4.encodingInterval.min
+	 * @property {number} MPEG4.encodingInterval.max
+	 * @property {object} MPEG4.govLengthRange Range of group of video frames length settings
+	 * @property {number} MPEG4.govLengthRange.min
+	 * @property {number} MPEG4.govLengthRange.max
+	 * @property {object} MPEG4.MPEG4ProfilesSupported List of supported MPEG4 profiles enum {'SP', 'ASP'}
+	 * @property {object} [H264] Optional H.264 encoder settings ranges
+	 * @property {object} H264.resolutionsAvailable List of supported resolutions
+	 * @property {number} H264.resolutionsAvailable.width
+	 * @property {number} H264.resolutionsAvailable.height
+	 * @property {object} H264.frameRateRange Range of frame rate settings
+	 * @property {number} H264.frameRateRange.min
+	 * @property {number} H264.frameRateRange.max
+	 * @property {object} H264.encodingIntervalRange Range of encoding interval settings
+	 * @property {number} H264.encodingInterval.min
+	 * @property {number} H264.encodingInterval.max
+	 * @property {object} H264.govLengthRange Range of group of video frames length settings
+	 * @property {number} H264.govLengthRange.min
+	 * @property {number} H264.govLengthRange.max
+	 * @property {object} H264.H264ProfilesSupported List of supported H.264 profiles enum {'Baseline', 'Main', 'Extended', 'High'}
+	 * @property {object} [extension] Optional encoder extensions
+	 * @property {object} [extension.JPEG] Optional JPEG encoder settings ranges
+	 * @property {object} extension.JPEG.resolutionsAvailable List of supported resolutions
+	 * @property {number} extension.JPEG.resolutionsAvailable.width
+	 * @property {number} extension.JPEG.resolutionsAvailable.height
+	 * @property {object} extension.JPEG.frameRateRange Range of frame rate settings
+	 * @property {number} extension.JPEG.frameRateRange.min
+	 * @property {number} extension.JPEG.frameRateRange.max
+	 * @property {object} extension.JPEG.encodingIntervalRange Range of encoding interval settings
+	 * @property {number} extension.JPEG.encodingInterval.min
+	 * @property {number} extension.JPEG.encodingInterval.max
+	 * @property {object} extension.JPEG.bitrateRange Range of bitrate settings
+	 * @property {number} extension.JPEG.bitrateRange.min
+	 * @property {number} extension.JPEG.bitrateRange.max
+	 * @property {object} [extension.MPEG4] Optional MPEG4 encoder settings ranges
+	 * @property {object} extension.MPEG4.resolutionsAvailable List of supported resolutions
+	 * @property {number} extension.MPEG4.resolutionsAvailable.width
+	 * @property {number} extension.MPEG4.resolutionsAvailable.height
+	 * @property {object} extension.MPEG4.resolutionsAvailable List of supported resolutions
+	 * @property {object} extension.MPEG4.frameRateRange Range of frame rate settings
+	 * @property {number} extension.MPEG4.frameRateRange.min
+	 * @property {number} extension.MPEG4.frameRateRange.max
+	 * @property {object} extension.MPEG4.encodingIntervalRange Range of encoding interval settings
+	 * @property {number} extension.MPEG4.encodingInterval.min
+	 * @property {number} extension.MPEG4.encodingInterval.max
+	 * @property {object} extension.MPEG4.govLengthRange Range of group of video frames length settings
+	 * @property {number} extension.MPEG4.govLengthRange.min
+	 * @property {number} extension.MPEG4.govLengthRange.max
+	 * @property {object} extension.MPEG4.MPEG4ProfilesSupported List of supported MPEG4 profiles enum {'SP', 'ASP'}
+	 * @property {object} extension.MPEG4.bitrateRange Range of bitrate settings
+	 * @property {number} extension.MPEG4.bitrateRange.min
+	 * @property {number} extension.MPEG4.bitrateRange.max
+	 * @property {object} [extension.H264] Optional H.264 encoder settings ranges
+	 * @property {object} extension.H264.resolutionsAvailable List of supported resolutions
+	 * @property {number} extension.H264.resolutionsAvailable.width
+	 * @property {number} extension.H264.resolutionsAvailable.height
+	 * @property {object} extension.H264.frameRateRange Range of frame rate settings
+	 * @property {number} extension.H264.frameRateRange.min
+	 * @property {number} extension.H264.frameRateRange.max
+	 * @property {object} extension.H264.encodingIntervalRange Range of encoding interval settings
+	 * @property {number} extension.H264.encodingInterval.min
+	 * @property {number} extension.H264.encodingInterval.max
+	 * @property {object} extension.H264.govLengthRange Range of group of video frames length settings
+	 * @property {number} extension.H264.govLengthRange.min
+	 * @property {number} extension.H264.govLengthRange.max
+	 * @property {object} extension.H264.H264ProfilesSupported List of supported H.264 profiles enum {'Baseline', 'Main', 'Extended', 'High'}
+	 * @property {object} extension.H264.bitrateRange Range of bitrate settings
+	 * @property {number} extension.H264.bitrateRange.min
+	 * @property {number} extension.H264.bitrateRange.max
+	 * @property {object} [extension.extension] Even more optional extensions
+	 */
+
+	/**
+	 * @callback Cam~VideoEncoderConfigurationOptionsCallback
+	 * @property {?Error} error
+	 * @property {Cam~VideoEncoderConfigurationOptions} videoEncoderConfigurationOptions
+	 * @property {string} xml Raw SOAP response
+	 */
+
+	/**
+	 * Get existing video encoder configuration options by its token
+	 * If token is omitted tries first from #videoEncoderConfigurations array
+	 * @param {string} [token] Token of the requested video encoder configuration
+	 * @param {Cam~VideoEncoderConfigurationOptionsCallback} callback
+	 */
+	Cam.prototype.getVideoEncoderConfigurationOptions = function(token, callback) {
+		if (callback === undefined) {
+			callback = token;
+			if (this.videoEncoderConfigurations && this.videoEncoderConfigurations[0]) {
+				token = this.videoEncoderConfigurations[0].$.token;
+			} else {
+				return callback(new Error('No video encoder configuration token is present!'));
+			}
 		}
-	}.bind(this));
-};
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetVideoEncoderConfigurationOptions xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+				'<ConfigurationToken>' + token + '</ConfigurationToken>' +
+			'</GetVideoEncoderConfigurationOptions>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data[0].getVideoEncoderConfigurationOptionsResponse[0].options), xml);
+			}
+		}.bind(this));
+	};
 
-/**
- * @typedef {object} Cam~VideoSourceConfiguration
- * @property {string} token Token that uniquely refernces this configuration
- * @property {string} sourceToken Reference to the physical input
- * @property {string} name User readable name
- * @property {number} useCount Number of internal references currently using this configuration
- * @property {object} bounds
- * @property {number} bounds.height
- * @property {number} bounds.width
- * @property {number} bounds.x
- * @property {number} bounds.y
- */
+	/**
+	 * Get all existing video encoder configurations of a device
+	 * @param {Cam~VideoEncoderConfigurationsCallback} callback
+	 */
+	Cam.prototype.getVideoEncoderConfigurations = function(callback) {
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetVideoEncoderConfigurations xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				this.videoEncoderConfigurations = data[0].getVideoEncoderConfigurationsResponse[0].configurations.map(function(config) {
+					return linerase(config);
+				});
+			}
+			if (callback) {
+				callback.call(this, err, this.videoEncoderConfigurations, xml);
+			}
+		}.bind(this));
+	};
 
-/**
- * @callback Cam~GetVideoSourceConfigurationsCallback
- * @property {?Error} error
- * @property {Array.<Cam~VideoSourceConfiguration>} videoSourceConfigurations
- * @property {string} xml Raw SOAP response
- */
-
-/**
- * Receive video sources
- * @param {Cam~GetVideoSourceConfigurationsCallback} [callback]
- */
-Cam.prototype.getVideoSourceConfigurations = function(callback) {
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetVideoSourceConfigurations xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			this.videoSourceConfigurations = data[0].getVideoSourceConfigurationsResponse[0].configurations.map(function(data) {
-				var obj =  linerase(data);
-				return {
-					token: obj.$.token
-					, name: obj.name
-					, useCount: obj.useCount
-					, sourceToken: obj.sourceToken
-					, bounds: {
-						height: obj.bounds.$.height
-						, width: obj.bounds.$.width
-						, x: obj.bounds.$.x
-						, y: obj.bounds.$.y
-					}
-				};
-			});
-		}
-		if (callback) {
-			callback.call(this, err, this.videoSourceConfigurations, xml);
-		}
-	}.bind(this));
-};
-
-/**
- * @typedef {object} Cam~VideoEncoderConfiguration
- * @property {string} $.token Token that uniquely refernces this configuration
- * @property {string} name User readable name.
- * @property {string} useCount Number of internal references currently using this configuration
- * @property {string} encoding Used video codec ('JPEG' | 'MPEG4' | 'H264' )
- * @property {object} resolution Configured video resolution
- * @property {number} resolution.width
- * @property {number} resolution.height
- * @property {number} quality Relative value for the video quantizers and the quality of the video. A high value within supported quality range means higher quality
- * @property {object} [rateControl] Optional element to configure rate control related parameters
- * @property {number} rateControl.frameRateLimit
- * @property {number} rateControl.encodingInterval
- * @property {number} rateControl.bitrateLimit
- * @property {object} [H264] Optional element to configure H.264 related parameters
- * @property {number} H264.govLength Group of Video frames length
- * @property {string} H264.H264profile the H.264 profile
- * @property {object} [MPEG4] Optional element to configure Mpeg4 related parameters
- * @property {number} MPEG4.govLength Determines the interval in which the I-Frames will be coded.
- * @property {string} MPEG4.MPEG4profile the Mpeg4 profile
- * @property {object} multicast
- * @property {string} multicast.address.type
- * @property {string} [multicast.address.IPv4Address]
- * @property {string} [multicast.address.IPv6Address]
- * @property {number} multicast.port
- * @property {number} multicast.TTL
- * @property {boolean} multicast.autoStart
- * @property {string} sessionTimeout The rtsp session timeout for the related video stream
- */
-
-/**
- * @callback Cam~VideoEncoderConfigurationCallback
- * @property {?Error} error
- * @property {Cam~VideoEncoderConfiguration} videoEncoderConfiguration
- * @property {string} xml Raw SOAP response
- */
-
-/**
- * @callback Cam~VideoEncoderConfigurationsCallback
- * @property {?Error} error
- * @property {Array.<Cam~VideoEncoderConfiguration>} videoEncoderConfigurations
- * @property {string} xml Raw SOAP response
- */
-
-/**
- * Get existing video encoder configuration by its token
- * If token is omitted tries first from #videoEncoderConfigurations array
- * @param {string} [token] Token of the requested video encoder configuration
- * @param {Cam~VideoEncoderConfigurationCallback} callback
- */
-Cam.prototype.getVideoEncoderConfiguration = function(token, callback) {
-	if (callback === undefined) {
-		callback = token;
-		if (this.videoEncoderConfigurations && this.videoEncoderConfigurations[0]) {
-			token = this.videoEncoderConfigurations[0].$.token;
-		} else {
+	/**
+	 * Set the device video encoder configuration
+	 * @param {object} options
+	 * @param {string} [options.token] Token that uniquely references this configuration.
+	 * @param {string} [options.$.token] Token that uniquely references this configuration.
+	 * @param {string} [options.name] User readable name.
+	 * @param {number} [options.useCount] Number of internal references (read-only)
+	 * @param {string} [options.encoding] ( JPEG | H264 | MPEG4 )
+	 * @param {object} [options.resolution] Configured video resolution
+	 * @param {number} options.resolution.width Number of the columns of the Video image
+	 * @param {number} options.resolution.height Number of the lines of the Video image
+	 * @param {number} options.quality Relative value for the video quantizers and the quality of the video
+	 * @param {object} [options.rateControl] Optional element to configure rate control related parameters
+	 * @param {number} options.rateControl.frameRateLimit Maximum output framerate in fps
+	 * @param {number} options.rateControl.encodingInterval Interval at which images are encoded and transmitted  (A value of 1 means that every frame is encoded, a value of 2 means that every 2nd frame is encoded ...)
+	 * @param {number} options.rateControl.bitrateLimit the maximum output bitrate in kbps
+	 * @param {object} [options.MPEG4]
+	 * @param {number} options.MPEG4.govLength Determines the interval in which the I-Frames will be coded
+	 * @param {string} options.MPEG4.profile the Mpeg4 profile ( SP | ASP )
+	 * @param {object} [options.H264]
+	 * @param {number} options.H264.govLength Group of Video frames length
+	 * @param {string} options.H264.profile the H.264 profile ( Baseline | Main | Extended | High )
+	 * @param {object} [options.multicast]
+	 * @param {object|number} [options.multicast.address] The multicast address (if this address is set to 0 no multicast streaming is enaled)
+	 * @param {string} options.multicast.address.type Indicates if the address is an IPv4 or IPv6 address ( IPv4 | IPv6)
+	 * @param {string} [options.multicast.address.IPv4Address]
+	 * @param {string} [options.multicast.address.IPv6Address]
+	 * @param {number} [options.multicast.port] The RTP mutlicast destination port
+	 * @param {number} [options.multicast.TTL]
+	 * @param {boolean} [options.multicast.autoStart]
+	 * @param {string} options.sessionTimeout
+	 * @param {Cam~VideoEncoderConfigurationCallback} callback
+	 */
+	Cam.prototype.setVideoEncoderConfiguration = function(options, callback) {
+		if (!options.token && !(options.$ && options.$.token)) {
 			return callback(new Error('No video encoder configuration token is present!'));
 		}
+		this._request({
+			service: 'media', 
+			body: this._envelopeHeader() +
+			'<SetVideoEncoderConfiguration xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+				'<Configuration token = "' + (options.token || options.$.token) + '">' +
+				( options.name ? '<Name xmlns="http://www.onvif.org/ver10/schema">' + options.name + '</Name>' : '' ) +
+				( options.useCount ? '<UseCount xmlns="http://www.onvif.org/ver10/schema">' + options.useCount + '</UseCount>' : '' ) +
+				( options.encoding ? '<Encoding xmlns="http://www.onvif.org/ver10/schema">' + options.encoding + '</Encoding>' : '' ) +
+				( options.resolution ?
+				'<Resolution xmlns="http://www.onvif.org/ver10/schema">' +
+					( options.resolution.width ? '<Width>' + options.resolution.width + '</Width>' : '') +
+					( options.resolution.height ? '<Height>' + options.resolution.height + '</Height>' : '') +
+				'</Resolution>' : '') +
+				( options.quality ? '<Quality xmlns="http://www.onvif.org/ver10/schema">' + options.quality + '</Quality>' : '' ) +
+				( options.rateControl ?
+				'<RateControl xmlns="http://www.onvif.org/ver10/schema">' +
+					( options.rateControl.frameRateLimit ? '<FrameRateLimit>' + options.rateControl.frameRateLimit + '</FrameRateLimit>' : '' ) +
+					( options.rateControl.encodingInterval ? '<EncodingInterval>' + options.rateControl.encodingInterval + '</EncodingInterval>' : '' ) +
+					( options.rateControl.bitrateLimit ? '<BitrateLimit>' + options.rateControl.bitrateLimit + '</BitrateLimit>' : '' ) +
+				'</RateControl>' : '' ) +
+				( options.MPEG4 ?
+				'<MPEG4 xmlns="http://www.onvif.org/ver10/schema">' +
+					( options.MPEG4.govLength ? '<GovLength>' + options.MPEG4.govLength + '</GovLength>' : '' ) +
+					( options.MPEG4.profile ? '<MPEG4Profile>' + options.MPEG4.profile + '</MPEG4Profile>' : '') +
+				'</MPEG4>' : '') +
+				( options.H264 ? '<H264 xmlns="http://www.onvif.org/ver10/schema">' +
+					( options.H264.govLength ? '<GovLength>' + options.H264.govLength + '</GovLength>' : '' ) +
+					( options.H264.profile ? '<H264Profile>' + options.H264.profile + '</H264Profile>' : '' ) +
+				'</H264>' : '') +
+				( options.multicast ?
+				'<Multicast xmlns="http://www.onvif.org/ver10/schema">' +
+					( options.multicast.address ?
+					'<Address>' +
+						( options.multicast.address === 0 ? '0' :
+							( options.multicast.address.type ? '<Type>' + options.multicast.address.type + '</Type>' : '' ) +
+							( options.multicast.address.IPv4Address ? '<IPv4Address>' + options.multicast.address.IPv4Address + '</IPv4Address>' : '') +
+							( options.multicast.address.IPv6Address ? '<IPv6Address>' + options.multicast.address.IPv6Address + '</IPv6Address>' : '')
+						) +
+					'</Address>' : '') +
+					( options.multicast.port !== undefined ? '<Port>' + options.multicast.port + '</Port>' : '' ) +
+					( options.multicast.TTL !== undefined ? '<TTL>' + options.multicast.TTL + '</TTL>' : '') +
+					( options.multicast.autoStart !== undefined ? '<AutoStart>' + options.multicast.autoStart + '</AutoStart>' : '') +
+				'</Multicast>' : '' ) +
+				( options.sessionTimeout ?
+				'<SessionTimeout xmlns="http://www.onvif.org/ver10/schema">' +
+					options.sessionTimeout +
+				'</SessionTimeout>' : '' ) +
+				'</Configuration>' +
+				'<ForcePersistence>true</ForcePersistence>' +
+			'</SetVideoEncoderConfiguration>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (err || linerase(data).setVideoEncoderConfigurationResponse !== '') {
+				return callback.call(this, linerase(data).setVideoEncoderConfigurationResponse !== ''
+					? new Error('Wrong `SetVideoEncoderConfiguration` response')
+					: err, data, xml);
+			}
+			//get new encoding settings from device
+			this.getVideoEncoderConfiguration(options.token || options.$.token, callback);
+		}.bind(this));
+	};
+
+	/**
+	 * Get all available physical audio iutputs  of a device
+	 * @param callback
+	 */
+	Cam.prototype.getAudioSources = function(callback) {
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetAudioSources xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				this.audioSources = data[0].getAudioSourcesResponse[0].audioSources.map(function(config) {
+					return linerase(config);
+				});
+			}
+			if (callback) {
+				callback.call(this, err, this.audioSources, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * Get all available audio encoder configurations of a device
+	 * @param callback
+	 */
+	Cam.prototype.getAudioEncoderConfigurations = function(callback) {
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetAudioEncoderConfigurations xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				this.audioEncoderConfigurations = data[0].getAudioEncoderConfigurationsResponse[0].configurations.map(function(config) {
+					return linerase(config);
+				});
+			}
+			if (callback) {
+				callback.call(this, err, this.audioEncoderConfigurations, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * Get all existing audio source configurations of a device
+	 * @param callback
+	 */
+	Cam.prototype.getAudioSourceConfigurations = function(callback) {
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetAudioSourceConfigurations xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				this.audioSourceConfigurations = data[0].getAudioSourceConfigurationsResponse[0].configurations.map(function(config) {
+					return linerase(config);
+				});
+			}
+			if (callback) {
+				callback.call(this, err, this.audioSourceConfigurations, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * Get all available audio outputs  of a device
+	 * @param callback
+	 */
+	Cam.prototype.getAudioOutputs = function(callback) {
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetAudioOutputs xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				this.audioOutputs = data[0].getAudioOutputsResponse[0].audioOutputs.map(function(config) {
+					return linerase(config);
+				});
+			}
+			if (callback) {
+				callback.call(this, err, this.audioOutputs, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * Get all existing audio output configurations of a device
+	 * @param callback
+	 */
+	Cam.prototype.getAudioOutputConfigurations = function(callback) {
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetAudioOutputConfigurations xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				this.audioOutputConfigurations = data[0].getAudioOutputConfigurationsResponse[0].configurations.map(function(config) {
+					return linerase(config);
+				});
+			}
+			if (callback) {
+				callback.call(this, err, this.audioOutputConfigurations, xml);
+			}
+		}.bind(this));
+	};
+
+	// TODO AddVideoEncoderConfiguration
+
+	/*
+	Cam.prototype.getVideoEncoderConfigurationOptions = function(options, callback) {
+	if (callback === undefined) {callback = options; options = {};}
+	this._request({
+	service: 'media'
+	, body: this._envelopeHeader() +
+	'<GetVideoEncoderConfigurationOptions xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+	this._envelopeFooter()
+	}, function(err, data, xml) {
+	if (!err) {
 	}
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetVideoEncoderConfiguration xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-			'<ConfigurationToken>' + token + '</ConfigurationToken>' +
-		'</GetVideoEncoderConfiguration>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) {
-			callback.call(this, err, err ? null : linerase(data[0].getVideoEncoderConfigurationResponse[0].configuration), xml);
-		}
-	}.bind(this));
-};
-
-/**
- * @typedef {object} Cam~VideoEncoderConfigurationOptions
- * @property {object} qualityRange Range of the quality values. A high value means higher quality
- * @property {number} qualityRange.min
- * @property {number} qualityRange.max
- * @property {object} [JPEG] Optional JPEG encoder settings ranges
- * @property {object} JPEG.resolutionsAvailable List of supported resolutions
- * @property {number} JPEG.resolutionsAvailable.width
- * @property {number} JPEG.resolutionsAvailable.height
- * @property {object} JPEG.frameRateRange Range of frame rate settings
- * @property {number} JPEG.frameRateRange.min
- * @property {number} JPEG.frameRateRange.max
- * @property {object} JPEG.encodingIntervalRange Range of encoding interval settings
- * @property {number} JPEG.encodingInterval.min
- * @property {number} JPEG.encodingInterval.max
- * @property {object} [MPEG4] Optional MPEG4 encoder settings ranges
- * @property {object} MPEG4.resolutionsAvailable List of supported resolutions
- * @property {number} MPEG4.resolutionsAvailable.width
- * @property {number} MPEG4.resolutionsAvailable.height
- * @property {object} MPEG4.resolutionsAvailable List of supported resolutions
- * @property {object} MPEG4.frameRateRange Range of frame rate settings
- * @property {number} MPEG4.frameRateRange.min
- * @property {number} MPEG4.frameRateRange.max
- * @property {object} MPEG4.encodingIntervalRange Range of encoding interval settings
- * @property {number} MPEG4.encodingInterval.min
- * @property {number} MPEG4.encodingInterval.max
- * @property {object} MPEG4.govLengthRange Range of group of video frames length settings
- * @property {number} MPEG4.govLengthRange.min
- * @property {number} MPEG4.govLengthRange.max
- * @property {object} MPEG4.MPEG4ProfilesSupported List of supported MPEG4 profiles enum {'SP', 'ASP'}
- * @property {object} [H264] Optional H.264 encoder settings ranges
- * @property {object} H264.resolutionsAvailable List of supported resolutions
- * @property {number} H264.resolutionsAvailable.width
- * @property {number} H264.resolutionsAvailable.height
- * @property {object} H264.frameRateRange Range of frame rate settings
- * @property {number} H264.frameRateRange.min
- * @property {number} H264.frameRateRange.max
- * @property {object} H264.encodingIntervalRange Range of encoding interval settings
- * @property {number} H264.encodingInterval.min
- * @property {number} H264.encodingInterval.max
- * @property {object} H264.govLengthRange Range of group of video frames length settings
- * @property {number} H264.govLengthRange.min
- * @property {number} H264.govLengthRange.max
- * @property {object} H264.H264ProfilesSupported List of supported H.264 profiles enum {'Baseline', 'Main', 'Extended', 'High'}
- * @property {object} [extension] Optional encoder extensions
- * @property {object} [extension.JPEG] Optional JPEG encoder settings ranges
- * @property {object} extension.JPEG.resolutionsAvailable List of supported resolutions
- * @property {number} extension.JPEG.resolutionsAvailable.width
- * @property {number} extension.JPEG.resolutionsAvailable.height
- * @property {object} extension.JPEG.frameRateRange Range of frame rate settings
- * @property {number} extension.JPEG.frameRateRange.min
- * @property {number} extension.JPEG.frameRateRange.max
- * @property {object} extension.JPEG.encodingIntervalRange Range of encoding interval settings
- * @property {number} extension.JPEG.encodingInterval.min
- * @property {number} extension.JPEG.encodingInterval.max
- * @property {object} extension.JPEG.bitrateRange Range of bitrate settings
- * @property {number} extension.JPEG.bitrateRange.min
- * @property {number} extension.JPEG.bitrateRange.max
- * @property {object} [extension.MPEG4] Optional MPEG4 encoder settings ranges
- * @property {object} extension.MPEG4.resolutionsAvailable List of supported resolutions
- * @property {number} extension.MPEG4.resolutionsAvailable.width
- * @property {number} extension.MPEG4.resolutionsAvailable.height
- * @property {object} extension.MPEG4.resolutionsAvailable List of supported resolutions
- * @property {object} extension.MPEG4.frameRateRange Range of frame rate settings
- * @property {number} extension.MPEG4.frameRateRange.min
- * @property {number} extension.MPEG4.frameRateRange.max
- * @property {object} extension.MPEG4.encodingIntervalRange Range of encoding interval settings
- * @property {number} extension.MPEG4.encodingInterval.min
- * @property {number} extension.MPEG4.encodingInterval.max
- * @property {object} extension.MPEG4.govLengthRange Range of group of video frames length settings
- * @property {number} extension.MPEG4.govLengthRange.min
- * @property {number} extension.MPEG4.govLengthRange.max
- * @property {object} extension.MPEG4.MPEG4ProfilesSupported List of supported MPEG4 profiles enum {'SP', 'ASP'}
- * @property {object} extension.MPEG4.bitrateRange Range of bitrate settings
- * @property {number} extension.MPEG4.bitrateRange.min
- * @property {number} extension.MPEG4.bitrateRange.max
- * @property {object} [extension.H264] Optional H.264 encoder settings ranges
- * @property {object} extension.H264.resolutionsAvailable List of supported resolutions
- * @property {number} extension.H264.resolutionsAvailable.width
- * @property {number} extension.H264.resolutionsAvailable.height
- * @property {object} extension.H264.frameRateRange Range of frame rate settings
- * @property {number} extension.H264.frameRateRange.min
- * @property {number} extension.H264.frameRateRange.max
- * @property {object} extension.H264.encodingIntervalRange Range of encoding interval settings
- * @property {number} extension.H264.encodingInterval.min
- * @property {number} extension.H264.encodingInterval.max
- * @property {object} extension.H264.govLengthRange Range of group of video frames length settings
- * @property {number} extension.H264.govLengthRange.min
- * @property {number} extension.H264.govLengthRange.max
- * @property {object} extension.H264.H264ProfilesSupported List of supported H.264 profiles enum {'Baseline', 'Main', 'Extended', 'High'}
- * @property {object} extension.H264.bitrateRange Range of bitrate settings
- * @property {number} extension.H264.bitrateRange.min
- * @property {number} extension.H264.bitrateRange.max
- * @property {object} [extension.extension] Even more optional extensions
- */
-
-/**
- * @callback Cam~VideoEncoderConfigurationOptionsCallback
- * @property {?Error} error
- * @property {Cam~VideoEncoderConfigurationOptions} videoEncoderConfigurationOptions
- * @property {string} xml Raw SOAP response
- */
-
-/**
- * Get existing video encoder configuration options by its token
- * If token is omitted tries first from #videoEncoderConfigurations array
- * @param {string} [token] Token of the requested video encoder configuration
- * @param {Cam~VideoEncoderConfigurationOptionsCallback} callback
- */
-Cam.prototype.getVideoEncoderConfigurationOptions = function(token, callback) {
-	if (callback === undefined) {
-		callback = token;
-		if (this.videoEncoderConfigurations && this.videoEncoderConfigurations[0]) {
-			token = this.videoEncoderConfigurations[0].$.token;
-		} else {
-			return callback(new Error('No video encoder configuration token is present!'));
-		}
+	if (callback) {
+	callback.call(this, err, this.videoEncoderConfigurations, xml);
 	}
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetVideoEncoderConfigurationOptions xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-			'<ConfigurationToken>' + token + '</ConfigurationToken>' +
-		'</GetVideoEncoderConfigurationOptions>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) {
-			callback.call(this, err, err ? null : linerase(data[0].getVideoEncoderConfigurationOptionsResponse[0].options), xml);
-		}
 	}.bind(this));
-};
+	};
+	*/
 
-/**
- * Get all existing video encoder configurations of a device
- * @param {Cam~VideoEncoderConfigurationsCallback} callback
- */
-Cam.prototype.getVideoEncoderConfigurations = function(callback) {
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetVideoEncoderConfigurations xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			this.videoEncoderConfigurations = data[0].getVideoEncoderConfigurationsResponse[0].configurations.map(function(config) {
-				return linerase(config);
-			});
-		}
-		if (callback) {
-			callback.call(this, err, this.videoEncoderConfigurations, xml);
-		}
-	}.bind(this));
-};
+	/**
+	 * @typedef {object} Cam~Profile
+	 * @property {object} $
+	 * @property {string} $.token profile token
+	 * @property {boolean} $.fixed is this a system or a user profile
+	 * @property {object} videoSourceConfiguration
+	 * @property {string} videoSourceConfiguration.$.token video source token
+	 * @property {object} videoEncoderConfiguration
+	 * @property {object} PTZConfiguration
+	 * @property {string} PTZConfiguration.$.token PTZ token
+	 * @property {string} PTZConfiguration.name PTZ configuration name
+	 */
 
-/**
- * Set the device video encoder configuration
- * @param {object} options
- * @param {string} [options.token] Token that uniquely references this configuration.
- * @param {string} [options.$.token] Token that uniquely references this configuration.
- * @param {string} [options.name] User readable name.
- * @param {number} [options.useCount] Number of internal references (read-only)
- * @param {string} [options.encoding] ( JPEG | H264 | MPEG4 )
- * @param {object} [options.resolution] Configured video resolution
- * @param {number} options.resolution.width Number of the columns of the Video image
- * @param {number} options.resolution.height Number of the lines of the Video image
- * @param {number} options.quality Relative value for the video quantizers and the quality of the video
- * @param {object} [options.rateControl] Optional element to configure rate control related parameters
- * @param {number} options.rateControl.frameRateLimit Maximum output framerate in fps
- * @param {number} options.rateControl.encodingInterval Interval at which images are encoded and transmitted  (A value of 1 means that every frame is encoded, a value of 2 means that every 2nd frame is encoded ...)
- * @param {number} options.rateControl.bitrateLimit the maximum output bitrate in kbps
- * @param {object} [options.MPEG4]
- * @param {number} options.MPEG4.govLength Determines the interval in which the I-Frames will be coded
- * @param {string} options.MPEG4.profile the Mpeg4 profile ( SP | ASP )
- * @param {object} [options.H264]
- * @param {number} options.H264.govLength Group of Video frames length
- * @param {string} options.H264.profile the H.264 profile ( Baseline | Main | Extended | High )
- * @param {object} [options.multicast]
- * @param {object|number} [options.multicast.address] The multicast address (if this address is set to 0 no multicast streaming is enaled)
- * @param {string} options.multicast.address.type Indicates if the address is an IPv4 or IPv6 address ( IPv4 | IPv6)
- * @param {string} [options.multicast.address.IPv4Address]
- * @param {string} [options.multicast.address.IPv6Address]
- * @param {number} [options.multicast.port] The RTP mutlicast destination port
- * @param {number} [options.multicast.TTL]
- * @param {boolean} [options.multicast.autoStart]
- * @param {string} options.sessionTimeout
- * @param {Cam~VideoEncoderConfigurationCallback} callback
- */
-Cam.prototype.setVideoEncoderConfiguration = function(options, callback) {
-	if (!options.token && !(options.$ && options.$.token)) {
-		return callback(new Error('No video encoder configuration token is present!'));
-	}
-	this._request({
-		service: 'media', 
-		body: this._envelopeHeader() +
-		'<SetVideoEncoderConfiguration xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-			'<Configuration token = "' + (options.token || options.$.token) + '">' +
-			( options.name ? '<Name xmlns="http://www.onvif.org/ver10/schema">' + options.name + '</Name>' : '' ) +
-			( options.useCount ? '<UseCount xmlns="http://www.onvif.org/ver10/schema">' + options.useCount + '</UseCount>' : '' ) +
-			( options.encoding ? '<Encoding xmlns="http://www.onvif.org/ver10/schema">' + options.encoding + '</Encoding>' : '' ) +
-			( options.resolution ?
-			'<Resolution xmlns="http://www.onvif.org/ver10/schema">' +
-				( options.resolution.width ? '<Width>' + options.resolution.width + '</Width>' : '') +
-				( options.resolution.height ? '<Height>' + options.resolution.height + '</Height>' : '') +
-			'</Resolution>' : '') +
-			( options.quality ? '<Quality xmlns="http://www.onvif.org/ver10/schema">' + options.quality + '</Quality>' : '' ) +
-			( options.rateControl ?
-			'<RateControl xmlns="http://www.onvif.org/ver10/schema">' +
-				( options.rateControl.frameRateLimit ? '<FrameRateLimit>' + options.rateControl.frameRateLimit + '</FrameRateLimit>' : '' ) +
-				( options.rateControl.encodingInterval ? '<EncodingInterval>' + options.rateControl.encodingInterval + '</EncodingInterval>' : '' ) +
-				( options.rateControl.bitrateLimit ? '<BitrateLimit>' + options.rateControl.bitrateLimit + '</BitrateLimit>' : '' ) +
-			'</RateControl>' : '' ) +
-			( options.MPEG4 ?
-			'<MPEG4 xmlns="http://www.onvif.org/ver10/schema">' +
-				( options.MPEG4.govLength ? '<GovLength>' + options.MPEG4.govLength + '</GovLength>' : '' ) +
-				( options.MPEG4.profile ? '<MPEG4Profile>' + options.MPEG4.profile + '</MPEG4Profile>' : '') +
-			'</MPEG4>' : '') +
-			( options.H264 ? '<H264 xmlns="http://www.onvif.org/ver10/schema">' +
-				( options.H264.govLength ? '<GovLength>' + options.H264.govLength + '</GovLength>' : '' ) +
-				( options.H264.profile ? '<H264Profile>' + options.H264.profile + '</H264Profile>' : '' ) +
-			'</H264>' : '') +
-			( options.multicast ?
-			'<Multicast xmlns="http://www.onvif.org/ver10/schema">' +
-				( options.multicast.address ?
-				'<Address>' +
-					( options.multicast.address === 0 ? '0' :
-						( options.multicast.address.type ? '<Type>' + options.multicast.address.type + '</Type>' : '' ) +
-						( options.multicast.address.IPv4Address ? '<IPv4Address>' + options.multicast.address.IPv4Address + '</IPv4Address>' : '') +
-						( options.multicast.address.IPv6Address ? '<IPv6Address>' + options.multicast.address.IPv6Address + '</IPv6Address>' : '')
-					) +
-				'</Address>' : '') +
-				( options.multicast.port !== undefined ? '<Port>' + options.multicast.port + '</Port>' : '' ) +
-				( options.multicast.TTL !== undefined ? '<TTL>' + options.multicast.TTL + '</TTL>' : '') +
-				( options.multicast.autoStart !== undefined ? '<AutoStart>' + options.multicast.autoStart + '</AutoStart>' : '') +
-			'</Multicast>' : '' ) +
-			( options.sessionTimeout ?
-			'<SessionTimeout xmlns="http://www.onvif.org/ver10/schema">' +
-				options.sessionTimeout +
-			'</SessionTimeout>' : '' ) +
-			'</Configuration>' +
-			'<ForcePersistence>true</ForcePersistence>' +
-		'</SetVideoEncoderConfiguration>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (err || linerase(data).setVideoEncoderConfigurationResponse !== '') {
-			return callback.call(this, linerase(data).setVideoEncoderConfigurationResponse !== ''
-				? new Error('Wrong `SetVideoEncoderConfiguration` response')
-				: err, data, xml);
-		}
-		//get new encoding settings from device
-		this.getVideoEncoderConfiguration(options.token || options.$.token, callback);
-	}.bind(this));
-};
+	/**
+	 * @callback Cam~GetProfilesCallback
+	 * @property {?Error} error
+	 * @property {Array.<Cam~Profile>} profiles Array of device's profiles
+	 * @property {string} xml Raw XML response
+	 */
 
-/**
- * Get all available physical audio iutputs  of a device
- * @param callback
- */
-Cam.prototype.getAudioSources = function(callback) {
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetAudioSources xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			this.audioSources = data[0].getAudioSourcesResponse[0].audioSources.map(function(config) {
-				return linerase(config);
-			});
-		}
-		if (callback) {
-			callback.call(this, err, this.audioSources, xml);
-		}
-	}.bind(this));
-};
+	/**
+	 * /Media/ Receive profiles
+	 * @param {Cam~GetProfilesCallback} [callback]
+	 */
+	Cam.prototype.getProfiles = function(callback) {
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetProfiles xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				/**
+				 * Array of all device profiles
+				 * @name Cam#profiles
+				 * @type {Array<Cam~Profile>}
+				 */
+				this.profiles = data[0]['getProfilesResponse'][0]['profiles'].map(function(profile) {
+					return linerase(profile);
+				});
+			}
+			if (callback) {
+				callback.call(this, err, this.profiles, xml);
+			}
+		}.bind(this));
+	};
 
-/**
- * Get all available audio encoder configurations of a device
- * @param callback
- */
-Cam.prototype.getAudioEncoderConfigurations = function(callback) {
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetAudioEncoderConfigurations xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			this.audioEncoderConfigurations = data[0].getAudioEncoderConfigurationsResponse[0].configurations.map(function(config) {
-				return linerase(config);
-			});
-		}
-		if (callback) {
-			callback.call(this, err, this.audioEncoderConfigurations, xml);
-		}
-	}.bind(this));
-};
+	/**
+	 * Create an empty new deletable media profile
+	 * @param options
+	 * @param {string} options.name Profile name
+	 * @param {string} [options.token] Profile token
+	 * @param {Cam~MessageCallback} callback
+	 */
+	Cam.prototype.createProfile = function(options, callback) {
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<CreateProfile xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+				'<Name>' + options.name + '</Name>' +
+				( options.token ? '<Token>' + options.token + '</Token>' : '' ) +
+			'</CreateProfile>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data).createProfileResponse.profile, xml);
+			}
+		}.bind(this));
+	};
 
-/**
- * Get all existing audio source configurations of a device
- * @param callback
- */
-Cam.prototype.getAudioSourceConfigurations = function(callback) {
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetAudioSourceConfigurations xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			this.audioSourceConfigurations = data[0].getAudioSourceConfigurationsResponse[0].configurations.map(function(config) {
-				return linerase(config);
-			});
-		}
-		if (callback) {
-			callback.call(this, err, this.audioSourceConfigurations, xml);
-		}
-	}.bind(this));
-};
+	/**
+	 * Delete a profile
+	 * @param {string} token
+	 * @param {Cam~MessageCallback} callback
+	 */
+	Cam.prototype.deleteProfile = function(token, callback) {
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<DeleteProfile xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+				'<ProfileToken>' + token + '</ProfileToken>' +
+			'</DeleteProfile>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data).deleteProfileResponse, xml);
+			}
+		}.bind(this));
+	};
 
-/**
- * Get all available audio outputs  of a device
- * @param callback
- */
-Cam.prototype.getAudioOutputs = function(callback) {
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetAudioOutputs xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			this.audioOutputs = data[0].getAudioOutputsResponse[0].audioOutputs.map(function(config) {
-				return linerase(config);
-			});
-		}
-		if (callback) {
-			callback.call(this, err, this.audioOutputs, xml);
-		}
-	}.bind(this));
-};
+	/**
+	 * @callback Cam~ResponseUriCallback
+	 * @property {string} uri
+	 */
 
-/**
- * Get all existing audio output configurations of a device
- * @param callback
- */
-Cam.prototype.getAudioOutputConfigurations = function(callback) {
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetAudioOutputConfigurations xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			this.audioOutputConfigurations = data[0].getAudioOutputConfigurationsResponse[0].configurations.map(function(config) {
-				return linerase(config);
-			});
-		}
-		if (callback) {
-			callback.call(this, err, this.audioOutputConfigurations, xml);
-		}
-	}.bind(this));
-};
+	/**
+	 * Receive stream URI
+	 * @param {Object} [options]
+	 * @param {string} [options.stream]
+	 * @param {string} [options.protocol]
+	 * @param {string} [options.profileToken]
+	 * @param {Cam~ResponseUriCallback} [callback]
+	 */
+	Cam.prototype.getStreamUri = function(options, callback) {
+		if (callback === undefined) { callback = options; options = {};	}
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetStreamUri xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+				'<StreamSetup>' +
+					'<Stream xmlns="http://www.onvif.org/ver10/schema">' + (options.stream || 'RTP-Unicast') +'</Stream>' +
+					'<Transport xmlns="http://www.onvif.org/ver10/schema">' +
+						'<Protocol>' + (options.protocol || 'RTSP') +'</Protocol>' +
+					'</Transport>' +
+				'</StreamSetup>' +
+				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) +'</ProfileToken>' +
+			'</GetStreamUri>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data).getStreamUriResponse.mediaUri, xml);
+			}
+		}.bind(this));
+	};
 
-// TODO AddVideoEncoderConfiguration
+	/**
+	 * Receive snapshot URI
+	 * @param {Object} [options]
+	 * @param {string} [options.profileToken]
+	 * @param {Cam~ResponseUriCallback} [callback]
+	 */
+	Cam.prototype.getSnapshotUri = function(options, callback) {
+		if (callback === undefined) { callback = options; options = {}; }
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetSnapshotUri xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) +'</ProfileToken>' +
+			'</GetSnapshotUri>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data).getSnapshotUriResponse.mediaUri, xml);
+			}
+		}.bind(this));
+	};
 
-/*
- Cam.prototype.getVideoEncoderConfigurationOptions = function(options, callback) {
- if (callback === undefined) {callback = options; options = {};}
- this._request({
- service: 'media'
- , body: this._envelopeHeader() +
- '<GetVideoEncoderConfigurationOptions xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
- this._envelopeFooter()
- }, function(err, data, xml) {
- if (!err) {
- }
- if (callback) {
- callback.call(this, err, this.videoEncoderConfigurations, xml);
- }
- }.bind(this));
- };
- */
-
-/**
- * @typedef {object} Cam~Profile
- * @property {object} $
- * @property {string} $.token profile token
- * @property {boolean} $.fixed is this a system or a user profile
- * @property {object} videoSourceConfiguration
- * @property {string} videoSourceConfiguration.$.token video source token
- * @property {object} videoEncoderConfiguration
- * @property {object} PTZConfiguration
- * @property {string} PTZConfiguration.$.token PTZ token
- * @property {string} PTZConfiguration.name PTZ configuration name
- */
-
-/**
- * @callback Cam~GetProfilesCallback
- * @property {?Error} error
- * @property {Array.<Cam~Profile>} profiles Array of device's profiles
- * @property {string} xml Raw XML response
- */
-
-/**
- * /Media/ Receive profiles
- * @param {Cam~GetProfilesCallback} [callback]
- */
-Cam.prototype.getProfiles = function(callback) {
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetProfiles xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			/**
-			 * Array of all device profiles
-			 * @name Cam#profiles
-			 * @type {Array<Cam~Profile>}
-			 */
-			this.profiles = data[0]['getProfilesResponse'][0]['profiles'].map(function(profile) {
-				return linerase(profile);
-			});
-		}
-		if (callback) {
-			callback.call(this, err, this.profiles, xml);
-		}
-	}.bind(this));
-};
-
-/**
- * Create an empty new deletable media profile
- * @param options
- * @param {string} options.name Profile name
- * @param {string} [options.token] Profile token
- * @param {Cam~MessageCallback} callback
- */
-Cam.prototype.createProfile = function(options, callback) {
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<CreateProfile xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-			'<Name>' + options.name + '</Name>' +
-			( options.token ? '<Token>' + options.token + '</Token>' : '' ) +
-		'</CreateProfile>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) {
-			callback.call(this, err, err ? null : linerase(data).createProfileResponse.profile, xml);
-		}
-	}.bind(this));
-};
-
-/**
- * Delete a profile
- * @param {string} token
- * @param {Cam~MessageCallback} callback
- */
-Cam.prototype.deleteProfile = function(token, callback) {
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<DeleteProfile xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-			'<ProfileToken>' + token + '</ProfileToken>' +
-		'</DeleteProfile>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) {
-			callback.call(this, err, err ? null : linerase(data).deleteProfileResponse, xml);
-		}
-	}.bind(this));
-};
-
-/**
- * @callback Cam~ResponseUriCallback
- * @property {string} uri
- */
-
-/**
- * Receive stream URI
- * @param {Object} [options]
- * @param {string} [options.stream]
- * @param {string} [options.protocol]
- * @param {string} [options.profileToken]
- * @param {Cam~ResponseUriCallback} [callback]
- */
-Cam.prototype.getStreamUri = function(options, callback) {
-	if (callback === undefined) { callback = options; options = {};	}
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetStreamUri xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-			'<StreamSetup>' +
-				'<Stream xmlns="http://www.onvif.org/ver10/schema">' + (options.stream || 'RTP-Unicast') +'</Stream>' +
-				'<Transport xmlns="http://www.onvif.org/ver10/schema">' +
-					'<Protocol>' + (options.protocol || 'RTSP') +'</Protocol>' +
-				'</Transport>' +
-			'</StreamSetup>' +
-			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) +'</ProfileToken>' +
-		'</GetStreamUri>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) {
-			callback.call(this, err, err ? null : linerase(data).getStreamUriResponse.mediaUri, xml);
-		}
-	}.bind(this));
-};
-
-/**
- * Receive snapshot URI
- * @param {Object} [options]
- * @param {string} [options.profileToken]
- * @param {Cam~ResponseUriCallback} [callback]
- */
-Cam.prototype.getSnapshotUri = function(options, callback) {
-	if (callback === undefined) { callback = options; options = {}; }
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetSnapshotUri xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) +'</ProfileToken>' +
-		'</GetSnapshotUri>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) {
-			callback.call(this, err, err ? null : linerase(data).getSnapshotUriResponse.mediaUri, xml);
-		}
-	}.bind(this));
-};
-
-/**
- * Get the OSDs.
- * @param {string} [token] Token of the Video Source Configuration, which has OSDs associated with are requested.
- * If token not exist, request all available OSDs.
- * @param {Cam~GetOSDsCallback} callback
- */
-Cam.prototype.getOSDs = function(token, callback) {
-	if (callback === undefined) { callback = token; token = ''; }
-	this._request({
-		service: 'media'
-		, body: this._envelopeHeader() +
-		'<GetOSDs xmlns="http://www.onvif.org/ver10/media/wsdl" >' +
-			(token ? '<ConfigurationToken>' + token + '</ConfigurationToken>' : '') +
-		'</GetOSDs>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) {
-			callback.call(this, err, err ? null : linerase(data), xml);
-		}
-	}.bind(this));
-};
+	/**
+	 * Get the OSDs.
+	 * @param {string} [token] Token of the Video Source Configuration, which has OSDs associated with are requested.
+	 * If token not exist, request all available OSDs.
+	 * @param {Cam~GetOSDsCallback} callback
+	 */
+	Cam.prototype.getOSDs = function(token, callback) {
+		if (callback === undefined) { callback = token; token = ''; }
+		this._request({
+			service: 'media'
+			, body: this._envelopeHeader() +
+			'<GetOSDs xmlns="http://www.onvif.org/ver10/media/wsdl" >' +
+				(token ? '<ConfigurationToken>' + token + '</ConfigurationToken>' : '') +
+			'</GetOSDs>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data), xml);
+			}
+		}.bind(this));
+	};
+}

--- a/lib/ptz.js
+++ b/lib/ptz.js
@@ -4,527 +4,527 @@
  * @author Andrew D.Laptev <a.d.laptev@gmail.com>
  * @licence MIT
  */
+module.exports = (Cam) => {
 
-const Cam = require('./cam').Cam
-	, extend = require('util')._extend
-	, linerase = require('./utils').linerase
-	, url = require('url')
-	;
+	const extend = require('util')._extend
+		, linerase = require('./utils').linerase
+		, url = require('url');
 
-/**
- * Receive cam presets
- * @param {object} [options]
- * @param {string} [options.profileToken]
- * @param [callback]
- */
-Cam.prototype.getPresets = function(options, callback) {
-	if (callback === undefined) { callback = options; options = {};	}
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<GetPresets xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) +'</ProfileToken>' +
-		'</GetPresets>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			this.presets = {};
-			var presets = linerase(data).getPresetsResponse.preset;
-			if (typeof presets !== 'undefined') {
-				if (!Array.isArray(presets)) {
-					presets = [presets];
+	/**
+	 * Receive cam presets
+	 * @param {object} [options]
+	 * @param {string} [options.profileToken]
+	 * @param [callback]
+	 */
+	Cam.prototype.getPresets = function(options, callback) {
+		if (callback === undefined) { callback = options; options = {};	}
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<GetPresets xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) +'</ProfileToken>' +
+			'</GetPresets>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				this.presets = {};
+				var presets = linerase(data).getPresetsResponse.preset;
+				if (typeof presets !== 'undefined') {
+					if (!Array.isArray(presets)) {
+						presets = [presets];
+					}
+					presets.forEach(function(preset) {
+						this.presets[preset.name] = preset.$.token;
+					}.bind(this));
 				}
-				presets.forEach(function(preset) {
-					this.presets[preset.name] = preset.$.token;
-				}.bind(this));
+			}
+			if (callback) {
+				callback.call(this, err, this.presets, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * /PTZ/ Go to preset
+	 * @param {object} options
+	 * @param {string} [options.profileToken]
+	 * @param {string} options.preset PresetName from {@link Cam#presets} property
+	 * @param {string} options.speed
+	 * @param {function} callback
+	 */
+	Cam.prototype.gotoPreset = function(options, callback) {
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<GotoPreset xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+				'<PresetToken>' + options.preset + '</PresetToken>' +
+				(options.speed ? '<Speed>' + this._panTiltZoomVectors(options.speed) + '</Speed>' : '') +
+			'</GotoPreset>' +
+			this._envelopeFooter()
+		}, callback.bind(this));
+	};
+	/**
+	 * /PTZ/ Set preset
+	 * @param {object} options
+	 * @param {string} [options.profileToken]
+	 * @param {string} options.presetName
+	 * @param {string} [options.presetToken]
+	 * @param {function} callback
+	 */
+	Cam.prototype.setPreset = function(options, callback) {
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<SetPreset xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+			'<PresetName>' + options.presetName + '</PresetName>' +
+			(options.presetToken ? '<PresetToken>' + options.presetToken + '</PresetToken>' : '') +
+			'</SetPreset>' +
+			this._envelopeFooter()
+		}, callback.bind(this));
+	};
+	/**
+	 * /PTZ/ Remove preset
+	 * @param {object} options
+	 * @param {string} [options.profileToken]
+	 * @param {string} options.presetToken
+	 * @param {function} callback
+	 */
+	Cam.prototype.removePreset = function(options,callback) {
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<RemovePreset xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+			'<PresetToken>' + options.presetToken + '</PresetToken>' +
+			'</RemovePreset>' +
+			this._envelopeFooter()
+		}, callback.bind(this));
+	};
+
+	/**
+	 * /PTZ/ Go to home position
+	 * @param {object} options
+	 * @param {string} [options.profileToken]
+	 * @param {object} [options.speed] If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
+	 * @param {number} [options.speed.x] Pan speed, float within 0 to 1
+	 * @param {number} [options.speed.y] Tilt speed, float within 0 to 1
+	 * @param {number} [options.speed.zoom] Zoom speed, float within 0 to 1
+	 * @param {function} callback
+	 */
+	Cam.prototype.gotoHomePosition = function(options, callback) {
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<GotoHomePosition xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+				(options.speed ? '<Speed>' + this._panTiltZoomVectors(options.speed) + '</Speed>' : '') +
+			'</GotoHomePosition>' +
+			this._envelopeFooter()
+		}, callback.bind(this));
+	};
+
+	/**
+	 * /PTZ/ Set home position
+	 * @param {object} options
+	 * @param {string} [options.profileToken]
+	 * @param {function} callback
+	 */
+	Cam.prototype.setHomePosition = function(options, callback) {
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<SetHomePosition xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+			'</SetHomePosition>' +
+			this._envelopeFooter()
+		}, callback.bind(this));
+	};
+
+	/**
+	 * @typedef {object} Cam~PTZStatus
+	 * @property {object} position
+	 * @property {number} position.x
+	 * @property {number} position.y
+	 * @property {number} position.zoom
+	 * @property {string} moveStatus
+	 * @property {?Error} error
+	 * @property {Date} utcTime
+	 */
+
+	/**
+	 * @callback Cam~GetPTZStatusCallback
+	 * @property {?Error} error
+	 * @property {Cam~PTZStatus} status
+	 */
+
+	/**
+	 * /PTZ/ Receive cam status
+	 * @param {Object} [options]
+	 * @param {string} [options.profileToken={@link Cam#activeSource.profileToken}]
+	 * @param {Cam~GetPTZStatusCallback} callback
+	 */
+	Cam.prototype.getStatus = function(options, callback) {
+		if (callback === undefined) { callback = options; options = {};	}
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<GetStatus xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) +'</ProfileToken>' +
+			'</GetStatus>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				var res = linerase(data).getStatusResponse.PTZStatus;
+				var status = {
+					position: {
+						x: res.position.panTilt.$.x
+						, y: res.position.panTilt.$.y
+						, zoom: res.position.zoom.$.x
+					}
+					, moveStatus: res.moveStatus
+					, error: res.error
+					, utcTime: res.utcTime
+				};
+			}
+			callback.call(this, err, err ? null : status, xml);
+		}.bind(this));
+	};
+
+	/**
+	 * /PTZ/ Returns the properties of the requested PTZ node, if it exists.
+	 * Use this function to get maximum number of presets, ranges of admitted values for x, y, zoom, iris, focus
+	 * @param {Function} callback
+	 */
+	Cam.prototype.getNodes = function(callback) {
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<GetNodes xmlns="http://www.onvif.org/ver20/ptz/wsdl" />' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				var nodes = this.nodes = {};
+				data[0]['getNodesResponse'].forEach(function(ptzNode) {
+					nodes[ptzNode['PTZNode'][0].$.token] = linerase(ptzNode['PTZNode'][0]);
+					delete nodes[ptzNode['PTZNode'][0].$.token].$;
+				});
+			}
+			callback.call(this, err, nodes, xml);
+		}.bind(this));
+	};
+
+	/**
+	 * /PTZ/ Get an array with configuration names
+	 * @param {Function} callback
+	 */
+	Cam.prototype.getConfigurations = function(callback) {
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<GetConfigurations xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+			'</GetConfigurations>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				var configurations = {};
+				data[0]['getConfigurationsResponse'].forEach(function(configuration) {
+					var pTZConfiguration = configuration['PTZConfiguration'][0];
+					var name = pTZConfiguration['name'];
+					// some cameras have this as an array instead of a string
+					if (Array.isArray(name)) {
+						name = name[0];
+					}
+					configurations[name] = {};
+					configurations[name].useCount = parseInt(pTZConfiguration['useCount']);
+					if ('$' in pTZConfiguration) {
+						configurations[name].token = pTZConfiguration['$']['token'];
+					}
+					if ('nodeToken' in pTZConfiguration) {
+						configurations[name].nodeToken = pTZConfiguration['nodeToken'][0];
+					}
+					if ('defaultPTZSpeed' in pTZConfiguration) {
+						var defaultPTZSpeed = pTZConfiguration['defaultPTZSpeed'][0];
+						configurations[name].defaultPTZSpeed = {};
+						if ('panTilt' in defaultPTZSpeed) {
+							configurations[name].defaultPTZSpeed.x = defaultPTZSpeed['panTilt'][0].$.x;
+							configurations[name].defaultPTZSpeed.y = defaultPTZSpeed['panTilt'][0].$.y;
+						}
+						if ('zoom' in defaultPTZSpeed) {
+							configurations[name].defaultPTZSpeed.zoom = defaultPTZSpeed['zoom'][0].$.x;
+						}
+					}
+					if ('defaultPTZTimeout' in pTZConfiguration) {
+						configurations[name].defaultPTZTimeout = pTZConfiguration['defaultPTZTimeout'][0];
+					}
+					if ('panTiltLimits' in pTZConfiguration) {
+						configurations[name].panTiltLimits = {};
+						var panTiltLimits = pTZConfiguration['panTiltLimits'][0]['range'][0];
+						configurations[name].panTiltLimits.XRange = {};
+						configurations[name].panTiltLimits.XRange.min = panTiltLimits.XRange[0].min[0];
+						configurations[name].panTiltLimits.XRange.max = panTiltLimits.XRange[0].max[0];
+						configurations[name].panTiltLimits.YRange = {};
+						configurations[name].panTiltLimits.YRange.min = panTiltLimits.YRange[0].min[0];
+						configurations[name].panTiltLimits.YRange.max = panTiltLimits.YRange[0].max[0];
+					}
+					if ('zoomLimits' in pTZConfiguration) {
+						configurations[name].zoomLimits = {};
+						var zoomLimits = pTZConfiguration['zoomLimits'][0]['range'][0];
+						configurations[name].zoomLimits.XRange = {};
+						configurations[name].zoomLimits.XRange.min = zoomLimits.XRange[0].min[0];
+						configurations[name].zoomLimits.XRange.max = zoomLimits.XRange[0].max[0];
+					}
+				});
+				this.configurations = configurations;
+			}
+			if (callback) {
+				callback.call(this, err, this.configurations, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * /PTZ/ Get options for the PTZ configuration
+	 * @param {string} configurationToken
+	 * @param {Function} callback
+	 */
+	Cam.prototype.getConfigurationOptions = function(configurationToken, callback) {
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<GetConfigurationOptions xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+				'<ConfigurationToken>' + configurationToken + '</ConfigurationToken>' +
+			'</GetConfigurationOptions>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			var configOptions;
+			if (!err) {
+				var sp = data[0]['getConfigurationOptionsResponse'][0]['PTZConfigurationOptions'][0]['spaces'][0];
+				configOptions = {
+					ptzTimeout: {
+						min: data[0]['getConfigurationOptionsResponse'][0]['PTZConfigurationOptions'][0]['PTZTimeout'][0]['min']
+						, max: data[0]['getConfigurationOptionsResponse'][0]['PTZConfigurationOptions'][0]['PTZTimeout'][0]['max']
+					}
+					, spaces: {
+						absolute: {
+							x: {
+								min: parseFloat(sp['absolutePanTiltPositionSpace'][0]['XRange'][0]['min'][0])
+								, max: parseFloat(sp['absolutePanTiltPositionSpace'][0]['XRange'][0]['max'][0])
+								, uri: sp['absolutePanTiltPositionSpace'][0]['URI']
+							}
+							, y: {
+								min: parseFloat(sp['absolutePanTiltPositionSpace'][0]['YRange'][0]['min'][0])
+								, max: parseFloat(sp['absolutePanTiltPositionSpace'][0]['YRange'][0]['max'][0])
+								, uri: sp['absolutePanTiltPositionSpace'][0]['URI']
+							}
+							, zoom: {
+								min: parseFloat(sp['absoluteZoomPositionSpace'][0]['XRange'][0]['min'][0])
+								, max: parseFloat(sp['absoluteZoomPositionSpace'][0]['XRange'][0]['max'][0])
+								, uri: sp['absoluteZoomPositionSpace'][0]['URI']
+							}
+						}
+						, relative: {
+							x: {
+								min: parseFloat(sp['relativePanTiltTranslationSpace'][0]['XRange'][0]['min'][0])
+								, max: parseFloat(sp['relativePanTiltTranslationSpace'][0]['XRange'][0]['max'][0])
+								, uri: sp['relativePanTiltTranslationSpace'][0]['URI']
+							}
+							, y: {
+								min: parseFloat(sp['relativePanTiltTranslationSpace'][0]['YRange'][0]['min'][0])
+								, max: parseFloat(sp['relativePanTiltTranslationSpace'][0]['YRange'][0]['max'][0])
+								, uri: sp['relativePanTiltTranslationSpace'][0]['URI']
+							}
+							, zoom: {
+								min: parseFloat(sp['relativeZoomTranslationSpace'][0]['XRange'][0]['min'][0])
+								, max: parseFloat(sp['relativeZoomTranslationSpace'][0]['XRange'][0]['max'][0])
+								, uri: sp['relativeZoomTranslationSpace'][0]['URI']
+							}
+						}
+						, continuous: {
+							x: {
+								min: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['XRange'][0]['min'][0])
+								, max: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['XRange'][0]['max'][0])
+								, uri: sp['continuousPanTiltVelocitySpace'][0]['URI']
+							}
+							, y: {
+								min: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['YRange'][0]['min'][0])
+								, max: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['YRange'][0]['max'][0])
+								, uri: sp['continuousPanTiltVelocitySpace'][0]['URI']
+							}
+							, zoom: {
+								min: parseFloat(sp['continuousZoomVelocitySpace'][0]['XRange'][0]['min'][0])
+								, max: parseFloat(sp['continuousZoomVelocitySpace'][0]['XRange'][0]['max'][0])
+								, uri: sp['continuousZoomVelocitySpace'][0]['URI']
+							}
+						}
+						, common: {
+							x: {
+								min: parseFloat(sp['panTiltSpeedSpace'][0]['XRange'][0]['min'][0])
+								, max: parseFloat(sp['panTiltSpeedSpace'][0]['XRange'][0]['max'][0])
+								, uri: sp['panTiltSpeedSpace'][0]['URI']
+							}
+							, zoom: {
+								min: parseFloat(sp['zoomSpeedSpace'][0]['XRange'][0]['min'][0])
+								, max: parseFloat(sp['zoomSpeedSpace'][0]['XRange'][0]['max'][0])
+								, uri: sp['zoomSpeedSpace'][0]['URI']
+							}
+						}
+					}
+				};
+				if (this.configurations[configurationToken]) {
+					extend(this.configurations[configurationToken], configOptions);
+				}
+			}
+			if (callback) {
+				callback.call(this, err, configOptions, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * /PTZ/ relative move
+	 * @param {object} options
+	 * @param {string} [options.profileToken=Cam#activeSource.profileToken]
+	 * @param {number} [options.x=0] Pan, float within -1 to 1
+	 * @param {number} [options.y=0] Tilt, float within -1 to 1
+	 * @param {number} [options.zoom=0] Zoom, float within 0 to 1
+	 * @param {object} [options.speed] If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
+	 * @param {number} [options.speed.x] Pan speed, float within 0 to 1
+	 * @param {number} [options.speed.y] Tilt speed, float within 0 to 1
+	 * @param {number} [options.speed.zoom] Zoom speed, float within 0 to 1
+	 * @param {Cam~RequestCallback} [callback]
+	 */
+	Cam.prototype.relativeMove = function(options, callback) {
+		callback = callback ? callback.bind(this) : function() {};
+		// Due to some glitches in testing cam forcibly set undefined move parameters to zero
+		options.x = options.x || 0;
+		options.y = options.y || 0;
+		options.zoom = options.zoom || 0;
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<RelativeMove xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+				'<Translation>' +
+					this._panTiltZoomVectors(options) +
+				'</Translation>' +
+				(options.speed ? '<Speed>' + this._panTiltZoomVectors(options.speed) + '</Speed>' : '') +
+			'</RelativeMove>' +
+			this._envelopeFooter()
+		}, callback.bind(this));
+	};
+
+	/**
+	 * /PTZ/ absolute move
+	 * @param {object} options
+	 * @param {string} [options.profileToken=Cam#activeSource.profileToken]
+	 * @param {number} [options.x] Pan, float within -1 to 1
+	 * @param {number} [options.y] Tilt, float within -1 to 1
+	 * @param {number} [options.zoom] Zoom, float within 0 to 1
+	 * @param {object} [options.speed] If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
+	 * @param {number} [options.speed.x] Pan speed, float within 0 to 1
+	 * @param {number} [options.speed.y] Tilt speed, float within 0 to 1
+	 * @param {number} [options.speed.zoom] Zoom speed, float within 0 to 1
+	 * @param {Cam~RequestCallback} [callback]
+	 */
+	Cam.prototype.absoluteMove = function(options, callback) {
+		callback = callback ? callback.bind(this) : function() {};
+		// Due to some glitches in testing cam forcibly set undefined move parameters to zero
+		options.x = options.x || 0;
+		options.y = options.y || 0;
+		options.zoom = options.zoom || 0;
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<AbsoluteMove xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+				'<Position>' +
+					this._panTiltZoomVectors(options) +
+				'</Position>' +
+				(options.speed ? '<Speed>' + this._panTiltZoomVectors(options.speed) + '</Speed>' : '') +
+			'</AbsoluteMove>' +
+			this._envelopeFooter()
+		}, callback.bind(this));
+	};
+
+	/**
+	 * /PTZ/ Operation for continuous Pan/Tilt and Zoom movements
+	 * @param options
+	 * @param {string} [options.profileToken=Cam#activeSource.profileToken]
+	 * @param {number} [options.x=0] pan velocity, float within 0 to 1
+	 * @param {number} [options.y=0] tilt velocity, float within 0 to 1
+	 * @param {number} [options.zoom=0] zoom velocity, float within 0 to 1
+	 * @param {number} [options.timeout=Infinity] timeout in milliseconds
+	 * @param {Cam~RequestCallback} callback
+	 */
+	Cam.prototype.continuousMove = function(options, callback) {
+		callback = callback ? callback.bind(this) : function() {};
+		// Due to some glitches in testing cam forcibly set undefined move parameters to zero
+		options.x = options.x || 0;
+		options.y = options.y || 0;
+		options.zoom = options.zoom || 0;
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<ContinuousMove xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+				'<Velocity>' +
+					this._panTiltZoomVectors(options) +
+				'</Velocity>' +
+				(options.timeout ? '<Timeout>PT' + (options.timeout / 1000) + 'S</Timeout>' : '') +
+			'</ContinuousMove>' +
+			this._envelopeFooter()
+		}, callback.bind(this));
+	};
+
+	/**
+	 * Stop ongoing pan, tilt and zoom movements of absolute relative and continuous type
+	 * @param {object} [options]
+	 * @param {string} [options.profileToken]
+	 * @param {boolean|string} [options.panTilt]
+	 * @param {boolean|string} [options.zoom]
+	 * @param {Cam~RequestCallback} [callback]
+	 */
+	Cam.prototype.stop = function(options, callback) {
+		if (callback === undefined) {
+			switch (typeof options) {
+				case 'object': callback = function() {}; break;
+				case 'function': callback = options; options = {}; break;
+				default: callback = function() {}; options = {};
 			}
 		}
-		if (callback) {
-			callback.call(this, err, this.presets, xml);
-		}
-	}.bind(this));
-};
+		this._request({
+			service: 'ptz'
+			, body: this._envelopeHeader() +
+			'<Stop xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
+				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+				(options.panTilt ? '<PanTilt>' + options.panTilt + '</PanTilt>' : '') +
+				(options.zoom ? '<Zoom>' + options.zoom + '</Zoom>' : '') +
+			'</Stop>' +
+			this._envelopeFooter()
+		}, callback.bind(this));
+	};
 
-/**
- * /PTZ/ Go to preset
- * @param {object} options
- * @param {string} [options.profileToken]
- * @param {string} options.preset PresetName from {@link Cam#presets} property
- * @param {string} options.speed
- * @param {function} callback
- */
-Cam.prototype.gotoPreset = function(options, callback) {
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<GotoPreset xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
-			'<PresetToken>' + options.preset + '</PresetToken>' +
-			(options.speed ? '<Speed>' + this._panTiltZoomVectors(options.speed) + '</Speed>' : '') +
-		'</GotoPreset>' +
-		this._envelopeFooter()
-	}, callback.bind(this));
-};
-/**
- * /PTZ/ Set preset
- * @param {object} options
- * @param {string} [options.profileToken]
- * @param {string} options.presetName
- * @param {string} [options.presetToken]
- * @param {function} callback
- */
-Cam.prototype.setPreset = function(options, callback) {
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<SetPreset xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-		'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
-		'<PresetName>' + options.presetName + '</PresetName>' +
-		(options.presetToken ? '<PresetToken>' + options.presetToken + '</PresetToken>' : '') +
-		'</SetPreset>' +
-		this._envelopeFooter()
-	}, callback.bind(this));
-};
-/**
- * /PTZ/ Remove preset
- * @param {object} options
- * @param {string} [options.profileToken]
- * @param {string} options.presetToken
- * @param {function} callback
- */
-Cam.prototype.removePreset = function(options,callback) {
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<RemovePreset xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-		'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
-		'<PresetToken>' + options.presetToken + '</PresetToken>' +
-		'</RemovePreset>' +
-		this._envelopeFooter()
-	}, callback.bind(this));
-};
-
-/**
- * /PTZ/ Go to home position
- * @param {object} options
- * @param {string} [options.profileToken]
- * @param {object} [options.speed] If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
- * @param {number} [options.speed.x] Pan speed, float within 0 to 1
- * @param {number} [options.speed.y] Tilt speed, float within 0 to 1
- * @param {number} [options.speed.zoom] Zoom speed, float within 0 to 1
- * @param {function} callback
- */
-Cam.prototype.gotoHomePosition = function(options, callback) {
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<GotoHomePosition xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
-			(options.speed ? '<Speed>' + this._panTiltZoomVectors(options.speed) + '</Speed>' : '') +
-		'</GotoHomePosition>' +
-		this._envelopeFooter()
-	}, callback.bind(this));
-};
-
-/**
- * /PTZ/ Set home position
- * @param {object} options
- * @param {string} [options.profileToken]
- * @param {function} callback
- */
-Cam.prototype.setHomePosition = function(options, callback) {
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<SetHomePosition xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
-		'</SetHomePosition>' +
-		this._envelopeFooter()
-	}, callback.bind(this));
-};
-
-/**
- * @typedef {object} Cam~PTZStatus
- * @property {object} position
- * @property {number} position.x
- * @property {number} position.y
- * @property {number} position.zoom
- * @property {string} moveStatus
- * @property {?Error} error
- * @property {Date} utcTime
- */
-
-/**
- * @callback Cam~GetPTZStatusCallback
- * @property {?Error} error
- * @property {Cam~PTZStatus} status
- */
-
-/**
- * /PTZ/ Receive cam status
- * @param {Object} [options]
- * @param {string} [options.profileToken={@link Cam#activeSource.profileToken}]
- * @param {Cam~GetPTZStatusCallback} callback
- */
-Cam.prototype.getStatus = function(options, callback) {
-	if (callback === undefined) { callback = options; options = {};	}
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<GetStatus xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) +'</ProfileToken>' +
-		'</GetStatus>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			var res = linerase(data).getStatusResponse.PTZStatus;
-			var status = {
-				position: {
-					x: res.position.panTilt.$.x
-					, y: res.position.panTilt.$.y
-					, zoom: res.position.zoom.$.x
-				}
-				, moveStatus: res.moveStatus
-				, error: res.error
-				, utcTime: res.utcTime
-			};
-		}
-		callback.call(this, err, err ? null : status, xml);
-	}.bind(this));
-};
-
-/**
- * /PTZ/ Returns the properties of the requested PTZ node, if it exists.
- * Use this function to get maximum number of presets, ranges of admitted values for x, y, zoom, iris, focus
- * @param {Function} callback
- */
-Cam.prototype.getNodes = function(callback) {
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<GetNodes xmlns="http://www.onvif.org/ver20/ptz/wsdl" />' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			var nodes = this.nodes = {};
-			data[0]['getNodesResponse'].forEach(function(ptzNode) {
-				nodes[ptzNode['PTZNode'][0].$.token] = linerase(ptzNode['PTZNode'][0]);
-				delete nodes[ptzNode['PTZNode'][0].$.token].$;
-			});
-		}
-		callback.call(this, err, nodes, xml);
-	}.bind(this));
-};
-
-/**
- * /PTZ/ Get an array with configuration names
- * @param {Function} callback
- */
-Cam.prototype.getConfigurations = function(callback) {
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<GetConfigurations xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-		'</GetConfigurations>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			var configurations = {};
-			data[0]['getConfigurationsResponse'].forEach(function(configuration) {
-				var pTZConfiguration = configuration['PTZConfiguration'][0];
-				var name = pTZConfiguration['name'];
-				// some cameras have this as an array instead of a string
-				if (Array.isArray(name)) {
-					name = name[0];
-				}
-				configurations[name] = {};
-				configurations[name].useCount = parseInt(pTZConfiguration['useCount']);
-				if ('$' in pTZConfiguration) {
-					configurations[name].token = pTZConfiguration['$']['token'];
-				}
-				if ('nodeToken' in pTZConfiguration) {
-					configurations[name].nodeToken = pTZConfiguration['nodeToken'][0];
-				}
-				if ('defaultPTZSpeed' in pTZConfiguration) {
-					var defaultPTZSpeed = pTZConfiguration['defaultPTZSpeed'][0];
-					configurations[name].defaultPTZSpeed = {};
-					if ('panTilt' in defaultPTZSpeed) {
-						configurations[name].defaultPTZSpeed.x = defaultPTZSpeed['panTilt'][0].$.x;
-						configurations[name].defaultPTZSpeed.y = defaultPTZSpeed['panTilt'][0].$.y;
-					}
-					if ('zoom' in defaultPTZSpeed) {
-						configurations[name].defaultPTZSpeed.zoom = defaultPTZSpeed['zoom'][0].$.x;
-					}
-				}
-				if ('defaultPTZTimeout' in pTZConfiguration) {
-					configurations[name].defaultPTZTimeout = pTZConfiguration['defaultPTZTimeout'][0];
-				}
-				if ('panTiltLimits' in pTZConfiguration) {
-					configurations[name].panTiltLimits = {};
-					var panTiltLimits = pTZConfiguration['panTiltLimits'][0]['range'][0];
-					configurations[name].panTiltLimits.XRange = {};
-					configurations[name].panTiltLimits.XRange.min = panTiltLimits.XRange[0].min[0];
-					configurations[name].panTiltLimits.XRange.max = panTiltLimits.XRange[0].max[0];
-					configurations[name].panTiltLimits.YRange = {};
-					configurations[name].panTiltLimits.YRange.min = panTiltLimits.YRange[0].min[0];
-					configurations[name].panTiltLimits.YRange.max = panTiltLimits.YRange[0].max[0];
-				}
-				if ('zoomLimits' in pTZConfiguration) {
-					configurations[name].zoomLimits = {};
-					var zoomLimits = pTZConfiguration['zoomLimits'][0]['range'][0];
-					configurations[name].zoomLimits.XRange = {};
-					configurations[name].zoomLimits.XRange.min = zoomLimits.XRange[0].min[0];
-					configurations[name].zoomLimits.XRange.max = zoomLimits.XRange[0].max[0];
-				}
-			});
-			this.configurations = configurations;
-		}
-		if (callback) {
-			callback.call(this, err, this.configurations, xml);
-		}
-	}.bind(this));
-};
-
-/**
- * /PTZ/ Get options for the PTZ configuration
- * @param {string} configurationToken
- * @param {Function} callback
- */
-Cam.prototype.getConfigurationOptions = function(configurationToken, callback) {
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<GetConfigurationOptions xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-			'<ConfigurationToken>' + configurationToken + '</ConfigurationToken>' +
-		'</GetConfigurationOptions>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		var configOptions;
-		if (!err) {
-			var sp = data[0]['getConfigurationOptionsResponse'][0]['PTZConfigurationOptions'][0]['spaces'][0];
-			configOptions = {
-				ptzTimeout: {
-					min: data[0]['getConfigurationOptionsResponse'][0]['PTZConfigurationOptions'][0]['PTZTimeout'][0]['min']
-					, max: data[0]['getConfigurationOptionsResponse'][0]['PTZConfigurationOptions'][0]['PTZTimeout'][0]['max']
-				}
-				, spaces: {
-					absolute: {
-						x: {
-							min: parseFloat(sp['absolutePanTiltPositionSpace'][0]['XRange'][0]['min'][0])
-							, max: parseFloat(sp['absolutePanTiltPositionSpace'][0]['XRange'][0]['max'][0])
-							, uri: sp['absolutePanTiltPositionSpace'][0]['URI']
-						}
-						, y: {
-							min: parseFloat(sp['absolutePanTiltPositionSpace'][0]['YRange'][0]['min'][0])
-							, max: parseFloat(sp['absolutePanTiltPositionSpace'][0]['YRange'][0]['max'][0])
-							, uri: sp['absolutePanTiltPositionSpace'][0]['URI']
-						}
-						, zoom: {
-							min: parseFloat(sp['absoluteZoomPositionSpace'][0]['XRange'][0]['min'][0])
-							, max: parseFloat(sp['absoluteZoomPositionSpace'][0]['XRange'][0]['max'][0])
-							, uri: sp['absoluteZoomPositionSpace'][0]['URI']
-						}
-					}
-					, relative: {
-						x: {
-							min: parseFloat(sp['relativePanTiltTranslationSpace'][0]['XRange'][0]['min'][0])
-							, max: parseFloat(sp['relativePanTiltTranslationSpace'][0]['XRange'][0]['max'][0])
-							, uri: sp['relativePanTiltTranslationSpace'][0]['URI']
-						}
-						, y: {
-							min: parseFloat(sp['relativePanTiltTranslationSpace'][0]['YRange'][0]['min'][0])
-							, max: parseFloat(sp['relativePanTiltTranslationSpace'][0]['YRange'][0]['max'][0])
-							, uri: sp['relativePanTiltTranslationSpace'][0]['URI']
-						}
-						, zoom: {
-							min: parseFloat(sp['relativeZoomTranslationSpace'][0]['XRange'][0]['min'][0])
-							, max: parseFloat(sp['relativeZoomTranslationSpace'][0]['XRange'][0]['max'][0])
-							, uri: sp['relativeZoomTranslationSpace'][0]['URI']
-						}
-					}
-					, continuous: {
-						x: {
-							min: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['XRange'][0]['min'][0])
-							, max: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['XRange'][0]['max'][0])
-							, uri: sp['continuousPanTiltVelocitySpace'][0]['URI']
-						}
-						, y: {
-							min: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['YRange'][0]['min'][0])
-							, max: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['YRange'][0]['max'][0])
-							, uri: sp['continuousPanTiltVelocitySpace'][0]['URI']
-						}
-						, zoom: {
-							min: parseFloat(sp['continuousZoomVelocitySpace'][0]['XRange'][0]['min'][0])
-							, max: parseFloat(sp['continuousZoomVelocitySpace'][0]['XRange'][0]['max'][0])
-							, uri: sp['continuousZoomVelocitySpace'][0]['URI']
-						}
-					}
-					, common: {
-						x: {
-							min: parseFloat(sp['panTiltSpeedSpace'][0]['XRange'][0]['min'][0])
-							, max: parseFloat(sp['panTiltSpeedSpace'][0]['XRange'][0]['max'][0])
-							, uri: sp['panTiltSpeedSpace'][0]['URI']
-						}
-						, zoom: {
-							min: parseFloat(sp['zoomSpeedSpace'][0]['XRange'][0]['min'][0])
-							, max: parseFloat(sp['zoomSpeedSpace'][0]['XRange'][0]['max'][0])
-							, uri: sp['zoomSpeedSpace'][0]['URI']
-						}
-					}
-				}
-			};
-			if (this.configurations[configurationToken]) {
-				extend(this.configurations[configurationToken], configOptions);
-			}
-		}
-		if (callback) {
-			callback.call(this, err, configOptions, xml);
-		}
-	}.bind(this));
-};
-
-/**
- * /PTZ/ relative move
- * @param {object} options
- * @param {string} [options.profileToken=Cam#activeSource.profileToken]
- * @param {number} [options.x=0] Pan, float within -1 to 1
- * @param {number} [options.y=0] Tilt, float within -1 to 1
- * @param {number} [options.zoom=0] Zoom, float within 0 to 1
- * @param {object} [options.speed] If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
- * @param {number} [options.speed.x] Pan speed, float within 0 to 1
- * @param {number} [options.speed.y] Tilt speed, float within 0 to 1
- * @param {number} [options.speed.zoom] Zoom speed, float within 0 to 1
- * @param {Cam~RequestCallback} [callback]
- */
-Cam.prototype.relativeMove = function(options, callback) {
-	callback = callback ? callback.bind(this) : function() {};
-	// Due to some glitches in testing cam forcibly set undefined move parameters to zero
-	options.x = options.x || 0;
-	options.y = options.y || 0;
-	options.zoom = options.zoom || 0;
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<RelativeMove xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
-			'<Translation>' +
-				this._panTiltZoomVectors(options) +
-			'</Translation>' +
-			(options.speed ? '<Speed>' + this._panTiltZoomVectors(options.speed) + '</Speed>' : '') +
-		'</RelativeMove>' +
-		this._envelopeFooter()
-	}, callback.bind(this));
-};
-
-/**
- * /PTZ/ absolute move
- * @param {object} options
- * @param {string} [options.profileToken=Cam#activeSource.profileToken]
- * @param {number} [options.x] Pan, float within -1 to 1
- * @param {number} [options.y] Tilt, float within -1 to 1
- * @param {number} [options.zoom] Zoom, float within 0 to 1
- * @param {object} [options.speed] If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
- * @param {number} [options.speed.x] Pan speed, float within 0 to 1
- * @param {number} [options.speed.y] Tilt speed, float within 0 to 1
- * @param {number} [options.speed.zoom] Zoom speed, float within 0 to 1
- * @param {Cam~RequestCallback} [callback]
- */
-Cam.prototype.absoluteMove = function(options, callback) {
-	callback = callback ? callback.bind(this) : function() {};
-	// Due to some glitches in testing cam forcibly set undefined move parameters to zero
-	options.x = options.x || 0;
-	options.y = options.y || 0;
-	options.zoom = options.zoom || 0;
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<AbsoluteMove xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
-			'<Position>' +
-				this._panTiltZoomVectors(options) +
-			'</Position>' +
-			(options.speed ? '<Speed>' + this._panTiltZoomVectors(options.speed) + '</Speed>' : '') +
-		'</AbsoluteMove>' +
-		this._envelopeFooter()
-	}, callback.bind(this));
-};
-
-/**
- * /PTZ/ Operation for continuous Pan/Tilt and Zoom movements
- * @param options
- * @param {string} [options.profileToken=Cam#activeSource.profileToken]
- * @param {number} [options.x=0] pan velocity, float within 0 to 1
- * @param {number} [options.y=0] tilt velocity, float within 0 to 1
- * @param {number} [options.zoom=0] zoom velocity, float within 0 to 1
- * @param {number} [options.timeout=Infinity] timeout in milliseconds
- * @param {Cam~RequestCallback} callback
- */
-Cam.prototype.continuousMove = function(options, callback) {
-	callback = callback ? callback.bind(this) : function() {};
-	// Due to some glitches in testing cam forcibly set undefined move parameters to zero
-	options.x = options.x || 0;
-	options.y = options.y || 0;
-	options.zoom = options.zoom || 0;
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<ContinuousMove xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
-			'<Velocity>' +
-				this._panTiltZoomVectors(options) +
-			'</Velocity>' +
-			(options.timeout ? '<Timeout>PT' + (options.timeout / 1000) + 'S</Timeout>' : '') +
-		'</ContinuousMove>' +
-		this._envelopeFooter()
-	}, callback.bind(this));
-};
-
-/**
- * Stop ongoing pan, tilt and zoom movements of absolute relative and continuous type
- * @param {object} [options]
- * @param {string} [options.profileToken]
- * @param {boolean|string} [options.panTilt]
- * @param {boolean|string} [options.zoom]
- * @param {Cam~RequestCallback} [callback]
- */
-Cam.prototype.stop = function(options, callback) {
-	if (callback === undefined) {
-		switch (typeof options) {
-			case 'object': callback = function() {}; break;
-			case 'function': callback = options; options = {}; break;
-			default: callback = function() {}; options = {};
-		}
-	}
-	this._request({
-		service: 'ptz'
-		, body: this._envelopeHeader() +
-		'<Stop xmlns="http://www.onvif.org/ver20/ptz/wsdl">' +
-			'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
-			(options.panTilt ? '<PanTilt>' + options.panTilt + '</PanTilt>' : '') +
-			(options.zoom ? '<Zoom>' + options.zoom + '</Zoom>' : '') +
-		'</Stop>' +
-		this._envelopeFooter()
-	}, callback.bind(this));
-};
-
-/**
- * Create ONVIF soap vector
- * @param [ptz.x]
- * @param [ptz.y]
- * @param [ptz.zoom]
- * @return {string}
- * @private
- */
-Cam.prototype._panTiltZoomVectors = function(ptz) {
-	return ptz
-		?
-	(ptz.x !== undefined && ptz.y !== undefined
-		? '<PanTilt x="' + ptz.x
-	+ '" y="' + ptz.y + '" xmlns="http://www.onvif.org/ver10/schema"/>'
-		: '') +
-	(ptz.zoom !== undefined
-		? '<Zoom x="'
-	+ ptz.zoom + '" xmlns="http://www.onvif.org/ver10/schema"/>'
-		: '')
-		: '';
-};
+	/**
+	 * Create ONVIF soap vector
+	 * @param [ptz.x]
+	 * @param [ptz.y]
+	 * @param [ptz.zoom]
+	 * @return {string}
+	 * @private
+	 */
+	Cam.prototype._panTiltZoomVectors = function(ptz) {
+		return ptz
+			?
+		(ptz.x !== undefined && ptz.y !== undefined
+			? '<PanTilt x="' + ptz.x
+		+ '" y="' + ptz.y + '" xmlns="http://www.onvif.org/ver10/schema"/>'
+			: '') +
+		(ptz.zoom !== undefined
+			? '<Zoom x="'
+		+ ptz.zoom + '" xmlns="http://www.onvif.org/ver10/schema"/>'
+			: '')
+			: '';
+	};
+}

--- a/lib/recording.js
+++ b/lib/recording.js
@@ -4,50 +4,50 @@
  * @author Roger Hardiman <opensource@rjh.org.uk>
  * @licence MIT
  */
+module.exports = (Cam) => {
 
-const Cam = require('./cam').Cam
-	, linerase = require('./utils').linerase
-	;
+	const linerase = require('./utils').linerase;
 
-/**
- * @typedef {object} Cam~RecordingItem
- * @property {string} $.token Recording token
- * @property {string} configuration.source.sourceid
- * @property {string} configuration.content
- * @property {string} configuration.maximumretentiontime
- * @property {string} tracks.track.tracktoken
- * @property {string} tracks.configuration.tracktype
- * @property {string} tracks.configuration.description
- */
+	/**
+	 * @typedef {object} Cam~RecordingItem
+	 * @property {string} $.token Recording token
+	 * @property {string} configuration.source.sourceid
+	 * @property {string} configuration.content
+	 * @property {string} configuration.maximumretentiontime
+	 * @property {string} tracks.track.tracktoken
+	 * @property {string} tracks.configuration.tracktype
+	 * @property {string} tracks.configuration.description
+	 */
 
-/**
- * @callback Cam~GetRecordingsCallback
- * @property {?Error} error
- * @property {Cam~RecordingItem|Array.<Cam~RecordingItem>} recording items
- * @property {string} xml Raw SOAP response
- */
+	/**
+	 * @callback Cam~GetRecordingsCallback
+	 * @property {?Error} error
+	 * @property {Cam~RecordingItem|Array.<Cam~RecordingItem>} recording items
+	 * @property {string} xml Raw SOAP response
+	 */
 
-/**
- * Get Recording Items (links Video Sources to Recording Tracks)
- * @param {Cam~GetRecordingsCallback} [callback]
- */
-Cam.prototype.getRecordings = function(callback) {
-	this._request({
-		service: 'recording'
-		, body: this._envelopeHeader() +
-		'<GetRecordings xmlns="http://www.onvif.org/ver10/recording/wsdl"/>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (!err) {
-			/**
-			 * Recording Item
-			 * @name Cam#recordingItem
-			 * @type {Cam~RecordingItem|Array.<Cam~RecordingItem>}
-			 */
-			this.recordingItems = linerase(data).getRecordingsResponse.recordingItem;
-		}
-		if (callback) {
-			callback.call(this, err, this.recordingItems, xml);
-		}
-	}.bind(this));
-};
+	/**
+	 * Get Recording Items (links Video Sources to Recording Tracks)
+	 * @param {Cam~GetRecordingsCallback} [callback]
+	 */
+	Cam.prototype.getRecordings = function(callback) {
+		this._request({
+			service: 'recording'
+			, body: this._envelopeHeader() +
+			'<GetRecordings xmlns="http://www.onvif.org/ver10/recording/wsdl"/>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (!err) {
+				/**
+				 * Recording Item
+				 * @name Cam#recordingItem
+				 * @type {Cam~RecordingItem|Array.<Cam~RecordingItem>}
+				 */
+				this.recordingItems = linerase(data).getRecordingsResponse.recordingItem;
+			}
+			if (callback) {
+				callback.call(this, err, this.recordingItems, xml);
+			}
+		}.bind(this));
+	};
+}

--- a/lib/replay.js
+++ b/lib/replay.js
@@ -4,42 +4,42 @@
  * @author Roger Hardiman <opensource@rjh.org.uk>
  * @licence MIT
  */
+module.exports = (Cam) => {
 
-const Cam = require('./cam').Cam
-	, linerase = require('./utils').linerase
-	;
+	const linerase = require('./utils').linerase;
 
-/**
- * @callback Cam~ResponseUriCallback
- * @property {string} uri
- */
+	/**
+	 * @callback Cam~ResponseUriCallback
+	 * @property {string} uri
+	 */
 
-/**
- * Receive Replay Stream URI
- * @param {Object} [options]
- * @param {string} [options.stream]
- * @param {string} [options.protocol]
- * @param {string} [options.recordingToken]
- * @param {Cam~ResponseUriCallback} [callback]
- */
-Cam.prototype.getReplayUri = function(options, callback) {
-	if (callback === undefined) { callback = options; options = {};	}
-	this._request({
-		service: 'replay'
-		, body: this._envelopeHeader() +
-		'<GetReplayUri xmlns="http://www.onvif.org/ver10/replay/wsdl">' +
-			'<StreamSetup>' +
-				'<Stream xmlns="http://www.onvif.org/ver10/schema">' + (options.stream || 'RTP-Unicast') +'</Stream>' +
-				'<Transport xmlns="http://www.onvif.org/ver10/schema">' +
-					'<Protocol>' + (options.protocol || 'RTSP') +'</Protocol>' +
-				'</Transport>' +
-			'</StreamSetup>' +
-			'<RecordingToken>' + (options.recordingToken) +'</RecordingToken>' +
-		'</GetReplayUri>' +
-		this._envelopeFooter()
-	}, function(err, data, xml) {
-		if (callback) {
-			callback.call(this, err, err ? null : linerase(data).getReplayUriResponse.uri, xml);
-		}
-	}.bind(this));
-};
+	/**
+	 * Receive Replay Stream URI
+	 * @param {Object} [options]
+	 * @param {string} [options.stream]
+	 * @param {string} [options.protocol]
+	 * @param {string} [options.recordingToken]
+	 * @param {Cam~ResponseUriCallback} [callback]
+	 */
+	Cam.prototype.getReplayUri = function(options, callback) {
+		if (callback === undefined) { callback = options; options = {};	}
+		this._request({
+			service: 'replay'
+			, body: this._envelopeHeader() +
+			'<GetReplayUri xmlns="http://www.onvif.org/ver10/replay/wsdl">' +
+				'<StreamSetup>' +
+					'<Stream xmlns="http://www.onvif.org/ver10/schema">' + (options.stream || 'RTP-Unicast') +'</Stream>' +
+					'<Transport xmlns="http://www.onvif.org/ver10/schema">' +
+						'<Protocol>' + (options.protocol || 'RTSP') +'</Protocol>' +
+					'</Transport>' +
+				'</StreamSetup>' +
+				'<RecordingToken>' + (options.recordingToken) +'</RecordingToken>' +
+			'</GetReplayUri>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data).getReplayUriResponse.uri, xml);
+			}
+		}.bind(this));
+	};
+}


### PR DESCRIPTION
I had a [hard time figuring out](https://stackoverflow.com/questions/49398078/porting-nodejs-module-to-react-native-object-prototype-undefined) why this module didn't work on react native even though I mapped nodejs's `net` and `stream` libraries to React Native compatible ones. Turns out it was a problem with cyclic dependencies in the way you splits class definition in the library. 

The best method I could find was to pass the already half built class object in the moment I require a new one, like this: 

```
Cam = function() {
...
}

require('./devices')(Cam)
require('./media')(Cam)
...
```

I didn't touch any other part of the code but the diffs are kinda wrong.

It's kinda ugly but it's necessary. Don't know if this is going to serve you but would be nice to have it working in both nodejs and react native. And I'm also going to build a good onvif app with it, because the ones in play store and app store don't fit my need.