### PR TITLE
Discovery now populates `urn` property of Cam instance

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -30,6 +30,7 @@ const http = require('http')
  * Camera class
  * @param {object} options
  * @param {string} options.hostname
+ * @param {string} options.urn
  * @param {string} [options.username]
  * @param {string} [options.password]
  * @param {number} [options.port=80]
@@ -69,6 +70,7 @@ const http = require('http')
 var Cam = function(options, callback) {
 	callback = callback || emptyFn;
 	this.hostname = options.hostname;
+	this.urn = options.urn;
 	this.username = options.username;
 	this.password = options.password;
 	this.port = options.port || 80;

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -120,6 +120,7 @@ Discovery.probe = function(options, callback) {
 							hostname: camUri.hostname
 							, port: camUri.port
 							, path: camUri.path
+							, urn: camAddr
 						});
 					} else {
 						cam = data;


### PR DESCRIPTION
URN property was only used to deduplicate discovered devices (using `probe()`).
Now it also populates a field on the Cam camera. 
When using Cam instances, this field can be used as a stable id (as opposed to IP address for instance)