### PR TITLE
Cam constructor has to call EventEmitter (super) constructor in order…

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -68,6 +68,7 @@ const http = require('http')
  * });
  */
 var Cam = function(options, callback) {
+	events.EventEmitter.call(this);
 	callback = callback || emptyFn;
 	this.hostname = options.hostname;
 	this.urn = options.urn;

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -125,7 +125,13 @@ Discovery.probe = function(options, callback) {
 							, urn: camAddr
 						});
 					} else {
-						cam = data;
+						var camUri = url.parse(data.probeMatches.probeMatch.XAddrs);
+						cam = {...data, 
+							hostname: camUri.hostname
+							, port: camUri.port
+							, path: camUri.path
+							, urn: camAddr
+						};
 					}
 					cams[camAddr] = cam;
 					/**

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -73,7 +73,7 @@ Discovery.probe = function(options, callback) {
 	var cams = {}
 		, errors = []
 		, messageID = 'urn:uuid:' + (options.messageId || guid())
-		, request = Buffer.from(
+		, request = new Buffer(
 			'<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope" xmlns:dn="http://www.onvif.org/ver10/network/wsdl">' +
 				'<Header>' +
 					'<wsa:MessageID xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">' + messageID + '</wsa:MessageID>' +
@@ -87,7 +87,7 @@ Discovery.probe = function(options, callback) {
 					'</Probe>' +
 				'</Body>' +
 			'</Envelope>' 
-		)
+		, 'utf8')
 		, socket = require('dgram').createSocket('udp4');
 
 	socket.on('error', function(err) {

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -150,6 +150,7 @@ Discovery.probe = function(options, callback) {
 		var interfaces = os.networkInterfaces();
 		// Try to find the interface based on the device name
 		if (options.device in interfaces) {
+			socket.addMembership(MULTICAST_ADDRESS, interfaces[options.device]);
 			interfaces[options.device].some(function(address) {
 				// Only use IPv4 addresses
 				if (address.family === 'IPv4') {

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -22,6 +22,8 @@ const
  */
 var Discovery = Object.create(new events.EventEmitter());
 
+const MULTICAST_ADDRESS = '239.255.255.250';
+const WS_DISCOVERY_MULTICAST_PORT = 3702;
 /**
  * @callback Discovery~ProbeCallback
  * @property {?Error} error
@@ -153,7 +155,7 @@ Discovery.probe = function(options, callback) {
 	}
 
 	socket.on('message', listener);
-	socket.send(request, 0, request.length, 3702, '239.255.255.250');
+	socket.send(request, 0, request.length, WS_DISCOVERY_MULTICAST_PORT, MULTICAST_ADDRESS);
 
 	setTimeout(function() {
 		socket.removeListener('message', listener);

--- a/lib/media.js
+++ b/lib/media.js
@@ -788,7 +788,14 @@ module.exports = function(Cam) {
 	 * @param {Cam~ResponseUriCallback} [callback]
 	 */
 	Cam.prototype.getStreamUri = function(options, callback) {
-		if (callback === undefined) { callback = options; options = {};	}
+		if (callback === undefined) { 
+			if (typeof options === 'function') {
+				callback = options;
+				options = {};
+			} else {
+				callback = () => {};
+			}
+		}
 		this._request({
 			service: 'media'
 			, body: this._envelopeHeader() +

--- a/lib/ptz.js
+++ b/lib/ptz.js
@@ -17,7 +17,14 @@ module.exports = function(Cam) {
 	 * @param [callback]
 	 */
 	Cam.prototype.getPresets = function(options, callback) {
-		if (callback === undefined) { callback = options; options = {};	}
+		if (callback === undefined) { 
+			if (typeof options === 'function') {
+				callback = options;
+				options = {};
+			} else {
+				callback = () => {};
+			}
+		}
 		this._request({
 			service: 'ptz'
 			, body: this._envelopeHeader() +
@@ -38,9 +45,7 @@ module.exports = function(Cam) {
 					}.bind(this));
 				}
 			}
-			if (callback) {
-				callback.call(this, err, this.presets, xml);
-			}
+			callback.call(this, err, this.presets, xml);
 		}.bind(this));
 	};
 
@@ -396,7 +401,14 @@ module.exports = function(Cam) {
 	 * @param {Cam~RequestCallback} [callback]
 	 */
 	Cam.prototype.relativeMove = function(options, callback) {
-		callback = callback ? callback.bind(this) : function() {};
+		if (callback === undefined) { 
+			if (typeof options === 'function') {
+				callback = options;
+				options = {};
+			} else {
+				callback = () => {};
+			}
+		}
 		// Due to some glitches in testing cam forcibly set undefined move parameters to zero
 		options.x = options.x || 0;
 		options.y = options.y || 0;
@@ -429,7 +441,14 @@ module.exports = function(Cam) {
 	 * @param {Cam~RequestCallback} [callback]
 	 */
 	Cam.prototype.absoluteMove = function(options, callback) {
-		callback = callback ? callback.bind(this) : function() {};
+		if (callback === undefined) { 
+			if (typeof options === 'function') {
+				callback = options;
+				options = {};
+			} else {
+				callback = () => {};
+			}
+		}
 		// Due to some glitches in testing cam forcibly set undefined move parameters to zero
 		options.x = options.x || 0;
 		options.y = options.y || 0;
@@ -459,7 +478,14 @@ module.exports = function(Cam) {
 	 * @param {Cam~RequestCallback} callback
 	 */
 	Cam.prototype.continuousMove = function(options, callback) {
-		callback = callback ? callback.bind(this) : function() {};
+		if (callback === undefined) { 
+			if (typeof options === 'function') {
+				callback = options;
+				options = {};
+			} else {
+				callback = () => {};
+			}
+		}
 		// Due to some glitches in testing cam forcibly set undefined move parameters to zero
 		options.x = options.x || 0;
 		options.y = options.y || 0;
@@ -489,7 +515,7 @@ module.exports = function(Cam) {
 	Cam.prototype.stop = function(options, callback) {
 		if (callback === undefined) {
 			switch (typeof options) {
-				case 'object': callback = function() {}; break;
+				case 'object': callback = callback || function() {}; break;
 				case 'function': callback = options; options = {}; break;
 				default: callback = function() {}; options = {};
 			}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -83,11 +83,10 @@ const parseSOAPString = function(xml, callback) {
 							reason = JSON.stringify(linerase(result.envelope.body[0].fault[0].code[0]));
 						}
 						var detail = '';
-						if (result.envelope.body[0].fault[0].detail && result.envelope.body[0].fault[0].detail[0].text[0]) {
-							detail = result.envelope.body[0].fault[0].detail[0].text[0];
+						if (result.envelope.body[0].fault[0].detail) {
+							detail = result.envelope.body[0].fault[0].detail[0].text ? result.envelope.body[0].fault[0].detail[0].text[0] : result.envelope.body[0].fault[0].detail[0];
 						}
-
-						// console.error('Fault:', reason, detail);
+						
 						err = new Error('ONVIF SOAP Fault: ' + (reason) + (detail));
 					}
 					callback(err, result['envelope']['body'], xml);


### PR DESCRIPTION
… for events not to be shared across separate Cam instances.
Without this call, all Cam instances share the same event listeners/handlers.
When trying to use instance specific handlers on separate instances of Cam objects, any instance triggering on of these events will result in all handlers being called (instead of just the one related to the instance an event originated from).