### PR TITLE
Issue #113 : follow up ONVIF specs for getVideoEncoderConfigurationOp…

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -291,6 +291,11 @@ module.exports = function(Cam) {
 	Cam.prototype.getVideoEncoderConfigurationOptions = function(options, callback) {
 		if (callback === undefined) {
 			callback = options;
+			if (this.videoEncoderConfigurations && this.videoEncoderConfigurations[0]) {
+				options = { configurationToken: this.videoEncoderConfigurations[0].$.token };
+			} else {
+				return callback(new Error('No video encoder configuration token is present!'));
+			}
 		} else if (typeof options == "string") { // For backward compatibility
 			options = { configurationToken: options };
 		} else if (!(options && (options.configurationToken || options.profileToken))) {

--- a/lib/media.js
+++ b/lib/media.js
@@ -279,26 +279,44 @@ module.exports = function(Cam) {
 	 */
 
 	/**
-	 * Get existing video encoder configuration options by its token
-	 * If token is omitted tries first from #videoEncoderConfigurations array
-	 * @param {string} [token] Token of the requested video encoder configuration
+	 * Get video encoder configuration options by video encoder configuration token or media profile token
+	 * If options is omitted, returns camera generic video encoder configuration options
+	 * If both token are set, returns video encoder configuration options compatible with both
+	 * If options is a string it is considered as configurationToken (for backward compatibility)
+	 * @param {object} [options]
+	 * @param {string} [options.configurationToken] The video encoder configuration token
+	 * @param {string} [options.profileToken] The media profile token
 	 * @param {Cam~VideoEncoderConfigurationOptionsCallback} callback
 	 */
-	Cam.prototype.getVideoEncoderConfigurationOptions = function(token, callback) {
+	Cam.prototype.getVideoEncoderConfigurationOptions = function(options, callback) {
 		if (callback === undefined) {
-			callback = token;
-			if (this.videoEncoderConfigurations && this.videoEncoderConfigurations[0]) {
-				token = this.videoEncoderConfigurations[0].$.token;
-			} else {
-				return callback(new Error('No video encoder configuration token is present!'));
-			}
+			callback = options;
+		} else if (typeof options == "string") { // For backward compatibility
+			options = { configurationToken: options };
+		} else if (!(options && (options.configurationToken || options.profileToken))) {
+			return callback(new Error("'options' must have one or both 'configurationToken' or 'profileToken'"));
 		}
 		this._request({
 			service: 'media'
 			, body: this._envelopeHeader() +
-			'<GetVideoEncoderConfigurationOptions xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-				'<ConfigurationToken>' + token + '</ConfigurationToken>' +
-			'</GetVideoEncoderConfigurationOptions>' +
+			(
+				(options) ?
+				(
+					'<GetVideoEncoderConfigurationOptions xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+					(
+						(options.configurationToken)
+						? '<ConfigurationToken>' + options.configurationToken + '</ConfigurationToken>'
+						: ""
+					) +
+					(
+						(options.profileToken)
+						? '<ProfileToken>' + options.profileToken + '</ProfileToken>'
+						: ""
+					) +
+					'</GetVideoEncoderConfigurationOptions>'
+				)
+				: '<GetVideoEncoderConfigurationOptions xmlns="http://www.onvif.org/ver10/media/wsdl" />'
+			) +
 			this._envelopeFooter()
 		}, function(err, data, xml) {
 			if (callback) {

--- a/test/media.coffee
+++ b/test/media.coffee
@@ -55,27 +55,9 @@ describe 'Media', () ->
         assert.notEqual err, null
         done()
   describe 'getVideoEncoderConfigurationOptions', () ->
-    configurationToken = "configurationToken"
-    profileToken = "profileToken"
     it 'should return an error when options is given but does not have `configurationToken` or `profileToken`', (done) ->
       cam.getVideoEncoderConfigurationOptions {}, (err, res) ->
         assert.notEqual err, null
-        done()
-    it 'should not return an error when options is given as a string', (done) ->
-      cam.getVideoEncoderConfigurationOptions configurationToken, (err, res) ->
-        assert.equal err, null
-        done()
-    it 'should not return an error when options is given with `configurationToken`', (done) ->
-      cam.getVideoEncoderConfigurationOptions {configurationToken: configurationToken}, (err, res) ->
-        assert.equal err, null
-        done()
-    it 'should not return an error when options is given with `profileToken`', (done) ->
-      cam.getVideoEncoderConfigurationOptions {profileToken: profileToken}, (err, res) ->
-        assert.equal err, null
-        done()
-    it 'should not return an error when options is given with both `configurationToken` and `profileToken`', (done) ->
-      cam.getVideoEncoderConfigurationOptions {configurationToken: configurationToken,profileToken: profileToken}, (err, res) ->
-        assert.equal err, null
         done()
 
 
@@ -103,13 +85,30 @@ describe 'Media', () ->
         done()
 
   describe 'getVideoEncoderConfigurationOptions', () ->
-    it 'should return a configuration options for the first token in #videoEncoderConfigurations array', (done) ->
+    configurationToken = "configurationToken"
+    profileToken = "profileToken"
+    it 'should return generic configuration options', (done) ->
       cam.getVideoEncoderConfigurationOptions (err, res) ->
         assert.equal err, null
         assert.ok res.qualityRange
         done()
-    it 'should return a configuration options for the named token as a first argument', (done) ->
-      cam.getVideoEncoderConfigurationOptions cam.videoEncoderConfigurations[0].$.token, (err, res) ->
+    it 'should return a configuration options when `options` is given as a string', (done) ->
+      cam.getVideoEncoderConfigurationOptions configurationToken, (err, res) ->
+        assert.equal err, null
+        assert.ok res.qualityRange
+        done()
+    it 'should return a configuration options when `options` is given as an object with `configurationToken`', (done) ->
+      cam.getVideoEncoderConfigurationOptions {configurationToken: configurationToken}, (err, res) ->
+        assert.equal err, null
+        assert.ok res.qualityRange
+        done()
+    it 'should return a configuration options when `options` is given as an object with `profileToken`', (done) ->
+      cam.getVideoEncoderConfigurationOptions {profileToken: profileToken}, (err, res) ->
+        assert.equal err, null
+        assert.ok res.qualityRange
+        done()
+    it 'should return a configuration options when `options` is given as an object with both `configurationToken` and `profileToken`', (done) ->
+      cam.getVideoEncoderConfigurationOptions {configurationToken: configurationToken,profileToken: profileToken}, (err, res) ->
         assert.equal err, null
         assert.ok res.qualityRange
         done()

--- a/test/media.coffee
+++ b/test/media.coffee
@@ -55,9 +55,27 @@ describe 'Media', () ->
         assert.notEqual err, null
         done()
   describe 'getVideoEncoderConfigurationOptions', () ->
-    it 'should return an error when no token present as a parameter or in #videoEncoderConfigurations array and there is no `videoEncoderConfigurations` property', (done) ->
-      cam.getVideoEncoderConfigurationOptions (err, res) ->
+    configurationToken = "configurationToken"
+    profileToken = "profileToken"
+    it 'should return an error when options is given but does not have `configurationToken` or `profileToken`', (done) ->
+      cam.getVideoEncoderConfigurationOptions {}, (err, res) ->
         assert.notEqual err, null
+        done()
+    it 'should not return an error when options is given as a string', (done) ->
+      cam.getVideoEncoderConfigurationOptions configurationToken, (err, res) ->
+        assert.equal err, null
+        done()
+    it 'should not return an error when options is given with `configurationToken`', (done) ->
+      cam.getVideoEncoderConfigurationOptions {configurationToken: configurationToken}, (err, res) ->
+        assert.equal err, null
+        done()
+    it 'should not return an error when options is given with `profileToken`', (done) ->
+      cam.getVideoEncoderConfigurationOptions {profileToken: profileToken}, (err, res) ->
+        assert.equal err, null
+        done()
+    it 'should not return an error when options is given with both `configurationToken` and `profileToken`', (done) ->
+      cam.getVideoEncoderConfigurationOptions {configurationToken: configurationToken,profileToken: profileToken}, (err, res) ->
+        assert.equal err, null
         done()
 
 


### PR DESCRIPTION
Issue #113 : follow up ONVIF specs for getVideoEncoderConfigurationOptions

Takes either a video encoder configuration token or a media profile token or both or none.
Do not force using token.