### PR TITLE
Issue #95 : problem with multiple XADDR

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -115,13 +115,15 @@ Discovery.probe = function(options, callback) {
 				if (!cams[camAddr]) {
 					var cam;
 					if (options.resolve !== false) {
-						var camUri = url.parse(data.probeMatches.probeMatch.XAddrs);
+						var XAddrs = data.probeMatches.probeMatch.XAddrs.split(" "); // Can contain more than one separated by spaces
+						var camUri = url.parse(XAddrs[0]); // Parse the first one as default
 						cam = new Cam({
 							hostname: camUri.hostname
 							, port: camUri.port
 							, path: camUri.path
 							, urn: camAddr
 						});
+						cam.XAddrs = XAddrs; // In case there are more than one, so the user can know all of them
 					} else {
 						cam = data;
 					}


### PR DESCRIPTION
Split XAddrs and parse only the first one.
Add XAddrs to Cam object so the user can know all of them.