### PR TITLE
Improve Events and ServerMockup

### DIFF
--- a/example6.js
+++ b/example6.js
@@ -1,16 +1,20 @@
 /**
  * NodeJS ONVIF Events
+ * Reveive Events using a PullPoint Subscription and display the events on screen
+ * Tested with Axis (which uses a fixed PullPoint URL with a SubscriberId in the XML)
+ * and with HikVision (which uses a dynamically generated PullPoint URL)
  *
  * Created by Roger Hardiman <opensource@rjh.org.uk>
- *
- * Register for Events and write them to stdout
  * 
+ * (c) Roger Hardiman, RJH Technical Consultancy Ltd, November 2019
+ * Licenced under the MIT Open Source Licence
+ *
  */
 
-let HOSTNAME = '192.168.1.151',
+let HOSTNAME = '127.0.0.1',
     PORT = 10101,
-    USERNAME = 'onvifuser',
-    PASSWORD = 'xxxx';
+    USERNAME = 'user',
+    PASSWORD = 'pass';
 
 let Cam = require('./lib/onvif').Cam;
 let flow = require('nimble');
@@ -20,7 +24,8 @@ new Cam({
 	username : USERNAME,
 	password : PASSWORD,
 	port : PORT,
-	timeout : 10000
+    timeout : 10000,
+    preserveAddress : true   // Enables NAT support and re-writes for PullPointSubscription URL
 }, function CamFunc(err) {
 	if (err) {
 		console.log(err);
@@ -37,14 +42,34 @@ new Cam({
     // Use Nimbe's flow to execute ONVIF commands in sequence
     flow.series([
         function(callback) {
+            cam_obj.getDeviceInformation(function(err, info, xml) {
+                if (!err) console.log('Manufacturer  ' + info.manufacturer);
+                if (!err) console.log('Model         ' + info.model);
+                if (!err) console.log('Firmware      ' + info.firmwareVersion);
+                if (!err) console.log('Serial Number ' + info.serialNumber);
+                callback();
+            });
+        },
+        function(callback) {
+            cam_obj.getSystemDateAndTime(function(err, date, xml) {
+                if (!err) console.log('Device Time   ' + date);
+                callback();
+            });
+        },
+        function(callback) {
                 cam_obj.getCapabilities(function(err, data, xml) {
                 if (err) {
                     console.log(err);
                 }
                 if (!err && data.events && data.events.WSPullPointSupport && data.events.WSPullPointSupport == true) {
-                    console.log('Camera Events service found');
+                    console.log('Camera supports WSPullPoint');
                     hasEvents = true;
+                } else {
+                    console.log('Camera does not show WSPullPoint support, but trying anyway');
+                    // Have an Axis cameras that says False to WSPullPointSuppor but supports it anyway
+                    hasEvents = true; // Hack for Axis cameras
                 }
+
                 if (hasEvents == false) {
                     console.log('This camera/NVT does not support PullPoint Events')
                 }

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -865,13 +865,13 @@ Cam.prototype._envelopeFooter = function() {
  */
 Cam.prototype._parseUrl = function(address) {
 	const parsedAddress = url.parse(address);
-	// If host for service and default host dirrers, also if preserve address property set
-	// we substitute host, hostname and port from settings
+	// If host for service and default host differs, also if preserve address property set
+	// we substitute host, hostname and port from settings then rebuild the href using .format
 	if (this.preserveAddress && this.hostname !== parsedAddress.hostname) {
 		parsedAddress.hostname = this.hostname;
-		parsedAddress.host = this.hostname;
+		parsedAddress.host = this.hostname + ':' + this.port;
 		parsedAddress.port = this.port;
-		parsedAddress.href = address;
+		parsedAddress.href = url.format(parsedAddress);
 	}
 	return parsedAddress;
 };

--- a/lib/events.js
+++ b/lib/events.js
@@ -140,13 +140,15 @@ module.exports = function(Cam) {
 
 		try {
 			subscriptionId = this.events.subscription.subscriptionReference.referenceParameters.subscriptionId
-		} catch (e) {}
+		} catch (e) {
+			subscriptionId = null;
+		}
 
 		let sendXml = this._envelopeHeader(true)
 		
 		// Axis Cameras use a PullPoint URL and the Subscription ID
 		if (subscriptionId) {
-			sendXml += '<a:To mustUnderstand="1">' + urlAddress.href +'</a:To>' +  // TODO ADD PORT
+			sendXml += '<a:To mustUnderstand="1">' + urlAddress.href + '</a:To>' +
 					'<SubscriptionId xmlns="http://www.axis.com/2009/event" a:IsReferenceParameter="true">' + this.events.subscription.subscriptionReference.referenceParameters.subscriptionId + '</SubscriptionId>'
 		}
 		sendXml += '</s:Header>' +

--- a/lib/events.js
+++ b/lib/events.js
@@ -87,6 +87,7 @@ module.exports = function(Cam) {
 			service: 'events'
 			, body: this._envelopeHeader() +
 			'<CreatePullPointSubscription xmlns="http://www.onvif.org/ver10/events/wsdl"/>' +
+			'<InitialTerminationTime>PT60S</InitialTerminationTime>' +
 			this._envelopeFooter()
 		}, function(err, res, xml) {
 			if (!err) {
@@ -129,19 +130,35 @@ module.exports = function(Cam) {
 	 * @throws {Error} {@link Cam#events.subscription} must exists
 	 */
 	Cam.prototype.pullMessages = function(options, callback) {
+		let urlAddress = null;
+		let subscriptionId = null;
 		try {
-			var urlAddress = this.events.subscription.subscriptionReference.address;
+			urlAddress = this.events.subscription.subscriptionReference.address;
 		} catch (e) {
 			throw new Error('You should create pull-point subscription first!');
 		}
-		this._request({
-			url: urlAddress
-			, body: this._envelopeHeader() +
-			'<PullMessages xmlns="http://www.onvif.org/ver10/events/wsdl">' +
-				'<Timeout>PT' + ((options.timeout || 30000) / 1000) + 'S</Timeout>' +
-				'<MessageLimit>' + (options.messageLimit || 1) + '</MessageLimit>' +
-			'</PullMessages>' +
+
+		try {
+			subscriptionId = this.events.subscription.subscriptionReference.referenceParameters.subscriptionId
+		} catch (e) {}
+
+		let sendXml = this._envelopeHeader(true)
+		
+		// Axis Cameras use a PullPoint URL and the Subscription ID
+		if (subscriptionId) {
+			sendXml += '<a:To mustUnderstand="1">' + urlAddress.href +'</a:To>' +  // TODO ADD PORT
+					'<SubscriptionId xmlns="http://www.axis.com/2009/event" a:IsReferenceParameter="true">' + this.events.subscription.subscriptionReference.referenceParameters.subscriptionId + '</SubscriptionId>'
+		}
+		sendXml += '</s:Header>' +
+			'<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">' +
+				'<PullMessages xmlns="http://www.onvif.org/ver10/events/wsdl">' +
+					'<Timeout>PT' + ((options.timeout || 30000) / 1000) + 'S</Timeout>' +
+					'<MessageLimit>' + (options.messageLimit || 1) + '</MessageLimit>' +
+				'</PullMessages>' +
 			this._envelopeFooter()
+		this._request({
+			url: urlAddress,
+			body: sendXml
 		}, function(err, res, xml) {
 			if (!err) {
 				var data = linerase(res).pullMessagesResponse;

--- a/lib/events.js
+++ b/lib/events.js
@@ -86,8 +86,9 @@ module.exports = function(Cam) {
 		this._request({
 			service: 'events'
 			, body: this._envelopeHeader() +
-			'<CreatePullPointSubscription xmlns="http://www.onvif.org/ver10/events/wsdl"/>' +
-			'<InitialTerminationTime>PT60S</InitialTerminationTime>' +
+			'<CreatePullPointSubscription xmlns="http://www.onvif.org/ver10/events/wsdl">' +
+				'<InitialTerminationTime>PT60S</InitialTerminationTime>' +
+			'</CreatePullPointSubscription>' +
 			this._envelopeFooter()
 		}, function(err, res, xml) {
 			if (!err) {
@@ -146,8 +147,10 @@ module.exports = function(Cam) {
 
 		let sendXml = this._envelopeHeader(true)
 		
-		// Axis Cameras use a PullPoint URL and the Subscription ID
-		if (subscriptionId) {
+		if (!subscriptionId) {
+			sendXml += '<a:To>' + urlAddress.href + '</a:To>'
+		} else {
+			// Axis Cameras use a PullPoint URL and the Subscription ID
 			sendXml += '<a:To mustUnderstand="1">' + urlAddress.href + '</a:To>' +
 					'<SubscriptionId xmlns="http://www.axis.com/2009/event" a:IsReferenceParameter="true">' + this.events.subscription.subscriptionReference.referenceParameters.subscriptionId + '</SubscriptionId>'
 		}
@@ -169,6 +172,52 @@ module.exports = function(Cam) {
 		}.bind(this));
 	};
 
+	/**
+	 * Unsibscribe from pull-point subscription
+	 * @param {Cam~PullMessagesResponse} callback
+	 * @throws {Error} {@link Cam#events.subscription} must exists
+	 */
+	Cam.prototype.unsubscribe = function(callback) {
+		let urlAddress = null;
+		let subscriptionId = null;
+		try {
+			urlAddress = this.events.subscription.subscriptionReference.address;
+		} catch (e) {
+			throw new Error('You should create pull-point subscription first!');
+		}
+
+		try {
+			subscriptionId = this.events.subscription.subscriptionReference.referenceParameters.subscriptionId
+		} catch (e) {
+			subscriptionId = null;
+		}
+
+		let sendXml = this._envelopeHeader(true)
+		
+		if (!subscriptionId) {
+			sendXml += '<a:To>' + urlAddress.href + '</a:To>'
+		} else {
+			// Axis Cameras use a PullPoint URL and the Subscription ID
+			sendXml += '<a:To mustUnderstand="1">' + urlAddress.href + '</a:To>' +
+					'<SubscriptionId xmlns="http://www.axis.com/2009/event" a:IsReferenceParameter="true">' + this.events.subscription.subscriptionReference.referenceParameters.subscriptionId + '</SubscriptionId>'
+		}
+		sendXml += '</s:Header>' +
+			'<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">' +
+				'<Unsubscribe xmlns="http://docs.oasis-open.org/wsn/b-2"/>' +
+			this._envelopeFooter()
+		this._request({
+			url: urlAddress,
+			body: sendXml
+		}, function(err, res, xml) {
+			if (!err) {
+				var data = linerase(res).unsubscribeResponse;
+			}
+			if (callback) {
+				callback.call(this, err, data, xml);
+			}
+		}.bind(this));
+	};
+	
 	/**
 	 * Count time before pull-point subscription terminates
 	 * @param {Cam~CreatePullPointSubscriptionResponse} response
@@ -232,6 +281,10 @@ module.exports = function(Cam) {
 				}
 				this._eventRequest();
 			}.bind(this));
+		} else {
+			delete this.events.terminationTime;
+
+			this.unsubscribe();
 		}
 	};
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
       "name": "Jeff Galbraith",
       "email": "jgalbraith@intelliviewtech.com",
       "url": "http://intelliviewtech.com"
+    },
+    {
+      "name": "Roger Hardiman",
+      "email": "opensource@rjh.org.uk",
+      "url": "http://www.rjh.org.uk"
     }
   ],
   "repository": {
@@ -59,6 +64,7 @@
     "mocha": ">=2.1.0",
     "mocha-lcov-reporter": "0.0.1",
     "nimble": "^0.0.2",
-    "nyc": "^14.1.1"
+    "nyc": "^14.1.1",
+    "ip": "^1.1.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "jsdoc": "jsdoc ./lib/*.js --readme ./README.md --destination ./docs",
     "gh-pages": "jsdoc ./lib/*.js --readme ./README.md --destination ./",
     "lint": "eslint lib/*.js",
-    "coffee-tests": "coffee -c test/*.coffee",
+    "coffee-tests": "coffee -c ./test",
     "pretest": "npm run lint && npm run coffee-tests",
     "test": "nyc mocha",
     "test-js": "mocha 'test/**/*.test.js'",

--- a/startServerMockup.js
+++ b/startServerMockup.js
@@ -1,0 +1,19 @@
+// Run the Server Mockup
+// Default port is 10101
+
+
+console.log('Loading Server Mockup');
+
+process.env['VERBOSE'] = 'true';
+process.env['HOSTNAME'] = '192.168.1.151';
+let serverMockup = require('./test/serverMockup.js')
+
+console.log('Server Ready');
+
+// The server Mockup unrefs the HTTP Server and Discovery UDP Listener so NodeJS will and not wait for the http server to terminate
+// So we keep the server alive with a hack - a timer that runs every 24 hours
+
+setInterval(function () {
+    console.log('keepalive executed'); 
+}, 1000*60*60*24); 
+

--- a/startServerMockup.js
+++ b/startServerMockup.js
@@ -14,11 +14,7 @@ console.log('Starting Server Mockup at http://' + serverHostname + ':' + serverP
 
 let serverMockup = require('./test/serverMockup.js')
 
-// The server Mockup unrefs the HTTP Server and Discovery UDP Listener so NodeJS
-// will exit immediatly
-// We keep the server alive with an IntervalTimer that runs every 24 hours
+// ServerMockup keeps running until you call .close()
 
-setInterval(function () {
-    console.log('keepalive executed'); 
-}, 1000*60*60*24); 
+// serverMockup.close()
 

--- a/startServerMockup.js
+++ b/startServerMockup.js
@@ -1,17 +1,22 @@
 // Run the Server Mockup
-// Default port is 10101
 
+let ip = require('ip');
 
-console.log('Loading Server Mockup');
+let serverHostname = ip.address();
+let serverPort = '10101';
+let allowDiscovery = 'false';
 
+process.env['HOSTNAME'] = serverHostname;
+process.env['PORT'] = serverPort;
 process.env['VERBOSE'] = 'true';
-process.env['HOSTNAME'] = '192.168.1.151';
+
+console.log('Starting Server Mockup at http://' + serverHostname + ':' + serverPort + '/onvif/device_service');
+
 let serverMockup = require('./test/serverMockup.js')
 
-console.log('Server Ready');
-
-// The server Mockup unrefs the HTTP Server and Discovery UDP Listener so NodeJS will and not wait for the http server to terminate
-// So we keep the server alive with a hack - a timer that runs every 24 hours
+// The server Mockup unrefs the HTTP Server and Discovery UDP Listener so NodeJS
+// will exit immediatly
+// We keep the server alive with an IntervalTimer that runs every 24 hours
 
 setInterval(function () {
     console.log('keepalive executed'); 

--- a/test/discovery.coffee
+++ b/test/discovery.coffee
@@ -4,6 +4,10 @@ serverMockup = require('./serverMockup')
 
 describe 'Discovery', () ->
   this.timeout 10000
+
+  before () ->
+    if (process.platform == 'win32')
+      this.skip 'Skipping test on Windows'
   it 'should discover at least one device (mockup server)', (done) ->
     onvif.Discovery.probe {timeout: 1000}, (err, cams) ->
       assert.equal err, null

--- a/test/events.coffee
+++ b/test/events.coffee
@@ -60,11 +60,11 @@ describe 'Events', () ->
       assert.ok gotMessage > 0
       cam.removeListener 'event', onEvent
       done()
-    , 30
+    , 1000
 
   it 'should stop pulling when nobody is listen to `event` event', (done) ->
-    delete cam.events.terminationTime
+    # wait 1 second for any Pull requests still running when we removed the listener to complete
     setTimeout () ->
       assert.ok cam.events.terminationTime is undefined
       done()
-    , 30
+    , 1000

--- a/test/serverMockup.coffee
+++ b/test/serverMockup.coffee
@@ -77,8 +77,11 @@ discover.on 'message', (msg, rinfo) ->
       else
         discoverReply.send discoverMsg, 0, discoverMsg.length, rinfo.port, rinfo.address
 
-discover.bind 3702, () ->
-  discover.addMembership '239.255.255.250'
+if process.platform != 'win32'
+  if verbose
+    console.log 'Listening for Discovery Messages on Port 3702'
+  discover.bind 3702, () ->
+    discover.addMembership '239.255.255.250'
 
 server = http
   .createServer listener

--- a/test/serverMockup.coffee
+++ b/test/serverMockup.coffee
@@ -87,12 +87,17 @@ server = http
   .createServer listener
   .listen conf.port
 
-# Unref all the connections to make tests finish
-discover.unref()
-server.unref()
+close = () ->
+  discover.close()
+  discoverReply.close()
+  server.close()
+  if verbose
+    console.log 'Closing ServerMockup'
+
 
 module.exports = {
   server: server
   , conf: conf
   , discover: discover
+  , close: close
 }

--- a/test/serverMockup/GetCapabilities.xml
+++ b/test/serverMockup/GetCapabilities.xml
@@ -51,7 +51,7 @@
                 <tt:Events>
                     <tt:XAddr>http://192.168.68.111/onvif/services</tt:XAddr>
                     <tt:WSSubscriptionPolicySupport>false</tt:WSSubscriptionPolicySupport>
-                    <tt:WSPullPointSupport>false</tt:WSPullPointSupport>
+                    <tt:WSPullPointSupport>true</tt:WSPullPointSupport>
                     <tt:WSPausableSubscriptionManagerInterfaceSupport>false</tt:WSPausableSubscriptionManagerInterfaceSupport>
                 </tt:Events>
                 <tt:Imaging>

--- a/test/serverMockup/Probe.xml
+++ b/test/serverMockup/Probe.xml
@@ -2,7 +2,7 @@
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope" xmlns:SOAP-ENC="http://www.w3.org/2003/05/soap-encoding" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsdd="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" xmlns:dn="http://www.onvif.org/ver10/network/wsdl">
     <SOAP-ENV:Header>
         <wsa:MessageID>urn:uuid:01234567-dead-beef-baad-abcdeffedcba</wsa:MessageID>
-        <wsa:RelatesTo>urn:uuid:01234567-dead-beef-baad-abcdeffedcba</wsa:RelatesTo>
+        <wsa:RelatesTo>RELATES_TO</wsa:RelatesTo>
         <wsa:ReplyTo SOAP-ENV:mustUnderstand="true">
             <wsa:Address>http://schemas.xmlsoap.org/ws/2004/08/addressing/role/anonymous</wsa:Address>
         </wsa:ReplyTo>

--- a/test/serverMockup/Unsubscribe.xml
+++ b/test/serverMockup/Unsubscribe.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SOAP-ENV:Envelope
+  xmlns:SOAP-ENV="http://www.w3.org/2003/05/soap-envelope"
+  xmlns:wsa="http://www.w3.org/2005/08/addressing"
+  xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2" >
+  <SOAP-ENV:Header>
+    <wsa:Action>
+      http://docs.oasis-open.org/wsn/bw-2/SubscriptionManager/UnsubscribeResponse
+    </wsa:Action>
+  </SOAP-ENV:Header>
+  <SOAP-ENV:Body>
+    <wsnt:UnsubscribeResponse/>
+  </SOAP-ENV:Body>
+</SOAP-ENV:Envelope>

--- a/test/serverMockup/device.GetNetworkInterfaces.xml
+++ b/test/serverMockup/device.GetNetworkInterfaces.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:soapenc="http://www.w3.org/2003/05/soap-encoding" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" xmlns:trt="http://www.onvif.org/ver10/media/wsdl" xmlns:timg="http://www.onvif.org/ver20/imaging/wsdl" xmlns:tev="http://www.onvif.org/ver10/events/wsdl" xmlns:tptz="http://www.onvif.org/ver20/ptz/wsdl" xmlns:tan="http://www.onvif.org/ver20/analytics/wsdl" xmlns:tst="http://www.onvif.org/ver10/storage/wsdl" xmlns:ter="http://www.onvif.org/ver10/error" xmlns:dn="http://www.onvif.org/ver10/network/wsdl" xmlns:tns1="http://www.onvif.org/ver10/topics" xmlns:tmd="http://www.onvif.org/ver10/deviceIO/wsdl" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl" xmlns:wsoap12="http://schemas.xmlsoap.org/wsdl/soap12" xmlns:http="http://schemas.xmlsoap.org/wsdl/http" xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:wsadis="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2" xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:wstop="http://docs.oasis-open.org/wsn/t-1" xmlns:wsrf-bf="http://docs.oasis-open.org/wsrf/bf-2" xmlns:wsntw="http://docs.oasis-open.org/wsn/bw-2" xmlns:wsrf-rw="http://docs.oasis-open.org/wsrf/rw-2" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:wsrf-r="http://docs.oasis-open.org/wsrf/r-2" xmlns:trc="http://www.onvif.org/ver10/recording/wsdl" xmlns:tse="http://www.onvif.org/ver10/search/wsdl" xmlns:trp="http://www.onvif.org/ver10/replay/wsdl" xmlns:tnshik="http://www.hikvision.com/2011/event/topics" xmlns:hikwsd="http://www.onvifext.com/onvif/ext/ver10/wsdl" xmlns:hikxsd="http://www.onvifext.com/onvif/ext/ver10/schema" xmlns:tas="http://www.onvif.org/ver10/advancedsecurity/wsdl">
+   <env:Body>
+      <tds:GetNetworkInterfacesResponse>
+         <tds:NetworkInterfaces token="eth0">
+            <tt:Enabled>true</tt:Enabled>
+            <tt:Info>
+               <tt:Name>eth0</tt:Name>
+               <tt:HwAddress>28:57:be:65:7d:d5</tt:HwAddress>
+               <tt:MTU>1500</tt:MTU>
+            </tt:Info>
+            <tt:Link>
+               <tt:AdminSettings>
+                  <tt:AutoNegotiation>true</tt:AutoNegotiation>
+                  <tt:Speed>100</tt:Speed>
+                  <tt:Duplex>Full</tt:Duplex>
+               </tt:AdminSettings>
+               <tt:OperSettings>
+                  <tt:AutoNegotiation>true</tt:AutoNegotiation>
+                  <tt:Speed>100</tt:Speed>
+                  <tt:Duplex>Full</tt:Duplex>
+               </tt:OperSettings>
+               <tt:InterfaceType>0</tt:InterfaceType>
+            </tt:Link>
+            <tt:IPv4>
+               <tt:Enabled>true</tt:Enabled>
+               <tt:Config>
+                  <tt:Manual>
+                     <tt:Address>192.168.68.111</tt:Address>
+                     <tt:PrefixLength>24</tt:PrefixLength>
+                  </tt:Manual>
+                  <tt:DHCP>false</tt:DHCP>
+               </tt:Config>
+            </tt:IPv4>
+            <tt:IPv6>
+               <tt:Enabled>true</tt:Enabled>
+               <tt:Config>
+                  <tt:AcceptRouterAdvert>false</tt:AcceptRouterAdvert>
+                  <tt:DHCP>Off</tt:DHCP>
+                  <tt:LinkLocal>
+                     <tt:Address>fe80::2a57:beff:fe65:7dd5</tt:Address>
+                     <tt:PrefixLength>64</tt:PrefixLength>
+                  </tt:LinkLocal>
+                  <tt:FromDHCP>
+                     <tt:Address>fe80::2a57:beff:fe65:7dd5</tt:Address>
+                     <tt:PrefixLength>64</tt:PrefixLength>
+                  </tt:FromDHCP>
+               </tt:Config>
+            </tt:IPv6>
+         </tds:NetworkInterfaces>
+      </tds:GetNetworkInterfacesResponse>
+   </env:Body>
+</env:Envelope>

--- a/test/serverMockup/device.GetZeroConfiguration.xml
+++ b/test/serverMockup/device.GetZeroConfiguration.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope" xmlns:soapenc="http://www.w3.org/2003/05/soap-encoding" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tt="http://www.onvif.org/ver10/schema" xmlns:tds="http://www.onvif.org/ver10/device/wsdl" xmlns:trt="http://www.onvif.org/ver10/media/wsdl" xmlns:timg="http://www.onvif.org/ver20/imaging/wsdl" xmlns:tev="http://www.onvif.org/ver10/events/wsdl" xmlns:tptz="http://www.onvif.org/ver20/ptz/wsdl" xmlns:tan="http://www.onvif.org/ver20/analytics/wsdl" xmlns:tst="http://www.onvif.org/ver10/storage/wsdl" xmlns:ter="http://www.onvif.org/ver10/error" xmlns:dn="http://www.onvif.org/ver10/network/wsdl" xmlns:tns1="http://www.onvif.org/ver10/topics" xmlns:tmd="http://www.onvif.org/ver10/deviceIO/wsdl" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl" xmlns:wsoap12="http://schemas.xmlsoap.org/wsdl/soap12" xmlns:http="http://schemas.xmlsoap.org/wsdl/http" xmlns:d="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:wsadis="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsnt="http://docs.oasis-open.org/wsn/b-2" xmlns:wsa="http://www.w3.org/2005/08/addressing" xmlns:wstop="http://docs.oasis-open.org/wsn/t-1" xmlns:wsrf-bf="http://docs.oasis-open.org/wsrf/bf-2" xmlns:wsntw="http://docs.oasis-open.org/wsn/bw-2" xmlns:wsrf-rw="http://docs.oasis-open.org/wsrf/rw-2" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:wsrf-r="http://docs.oasis-open.org/wsrf/r-2" xmlns:trc="http://www.onvif.org/ver10/recording/wsdl" xmlns:tse="http://www.onvif.org/ver10/search/wsdl" xmlns:trp="http://www.onvif.org/ver10/replay/wsdl" xmlns:tnshik="http://www.hikvision.com/2011/event/topics" xmlns:hikwsd="http://www.onvifext.com/onvif/ext/ver10/wsdl" xmlns:hikxsd="http://www.onvifext.com/onvif/ext/ver10/schema" xmlns:tas="http://www.onvif.org/ver10/advancedsecurity/wsdl">
+   <env:Body>
+      <tds:GetZeroConfigurationResponse>
+         <tds:ZeroConfiguration>
+            <tt:InterfaceToken>eth0</tt:InterfaceToken>
+            <tt:Enabled>true</tt:Enabled>
+            <tt:Addresses>192.168.1.11</tt:Addresses>
+         </tds:ZeroConfiguration>
+      </tds:GetZeroConfigurationResponse>
+   </env:Body>
+</env:Envelope>

--- a/test/zzzterminate.coffee
+++ b/test/zzzterminate.coffee
@@ -1,0 +1,6 @@
+serverMockup = require('./serverMockup')
+
+describe 'Terminating', () ->
+  it 'should terminate serverMockup', (done) ->
+    serverMockup.close()
+    done()


### PR DESCRIPTION
Events.....    Changes to make events work with Axis cameras and with NAT.

There is a new file called example6.js which I am using to connect to 4 different cameras and to the serverMockup and can receive events from all of them.

The Axis events are not documented properly in the ONVIF Spec and I had to use ODM and Wireshark. They need to include a <To> tag and a <SubscriptionId> tag in the Pull Request.



ServerMockup.... made changes so discovery works properly and ODM now detects it. Added a few other XML stubs. The purpose was to get ODM to receive events from the ServerMockup so I could verify how ODM received events.