### PR TITLE
Issue #134 Improve xmlns parsing

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,7 +53,7 @@ const linerase = function(xml) {
  */
 const parseSOAPString = function(xml, callback) {
 	/* Filter out xml name spaces */
-	xml = xml.replace(/xmlns(.*?)=(".*?")/g,'');
+	xml = xml.replace(/xmlns([^=]*?)=(".*?")/g,'');
 
 	try {
 		xml2js.parseString(


### PR DESCRIPTION
Permit to remove xmlns in the Dialect of a PullMessagesResponse like the following:

```xml
<wsnt:Topic Dialect="http://www.onvif.org/ver10/tev/topicExpression/ConcreteSet xmlns:wsnt=http://docs.oasis-open.org/wsn/b-2 xmlns:tns1=http://www.onvif.org/ver10/topics xmlns:tnssamsung=http://www.samsungcctv.com/2011/event/topics">tns1:Device/tns1:Trigger/tnssamsung:DigitalInput</wsnt:Topic>
```