### PR TITLE
Add the possibility to bind an address on Discovery instead of a devi…

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -72,10 +72,12 @@ var Cam = function(options, callback) {
 	this.hostname = options.hostname;
 	this.username = options.username;
 	this.password = options.password;
+	this.urn = options.urn;
 	this.port = options.port || 80;
 	this.path = options.path || '/onvif/device_service';
 	this.timeout = options.timeout || 120000;
 	this.agent = options.agent || false;
+	this.localAddress = options.localAddress;
 	/**
 	 * Force using hostname and port from constructor for the services
 	 * @type {boolean}
@@ -193,6 +195,7 @@ Cam.prototype._request = function(options, callback) {
 	};
 
 	reqOptions.method = 'POST';
+	reqOptions.localAddress = this.localAddress;
 	var req = http.request(reqOptions, function(res) {
 		var bufs = [], length = 0;
 		res.on('data', function(chunk) {

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -141,14 +141,16 @@ Discovery.probe = function(options, callback) {
 					 * @event Discovery#device
 					 * @type {Cam|object}
 					 */
-					Discovery.emit('device', cam, rinfo, xml);
+					Discovery.emit('device', cam, {remote: rinfo, local: socket.address()}, xml);
 				}
 			}
 		});
 	};
 
 	// If device is specified try to bind to that interface
-	if (options.device) {
+	if (options.bindAddress) {
+		socket.bind(null,options.bindAddress);
+	} else if (options.device) {
 		var interfaces = os.networkInterfaces();
 		// Try to find the interface based on the device name
 		if (options.device in interfaces) {


### PR DESCRIPTION
Add the possibility to bind an address on Discovery instead of a device, in case a device has multiple aliases.
Because of address binding we need to know which alias received the camera, so we now send a remote and a local info in Discovery.emit('device'). **This breaks backward compatibility** though

The `urn` has been remvoved from the `Cam` constructor in a previous while it is set in [discovery.js](https://github.com/agsh/onvif/blob/2a7f9fe267058e8d069253f7d1189e5744b09470/lib/discovery.js#L126)
The `urn` is important to compare cameras, so I added it back.