### PR TITLE
Better SOAP error handling

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,15 +76,25 @@ const parseSOAPString = function(xml, callback) {
 					if (!err && result['envelope']['body'][0]['fault']) {
 						var fault = result['envelope']['body'][0]['fault'][0];
 						var reason;
-						if (fault['reason'][0]['text'][0]._) {
-							reason = fault['reason'][0]['text'][0]._;
+						try {
+							if (fault.reason[0].text[0]._) {
+								reason = fault.reason[0].text[0]._;
+							}
+						} catch (e) {
+							reason = '';
 						}
 						if (!reason) {
-							reason = JSON.stringify(linerase(result.envelope.body[0].fault[0].code[0]));
+							try {
+								reason = JSON.stringify(linerase(fault.code[0]));
+							} catch (e) {
+								reason = '';
+							}
 						}
 						var detail = '';
-						if (result.envelope.body[0].fault[0].detail && result.envelope.body[0].fault[0].detail[0].text[0]) {
-							detail = result.envelope.body[0].fault[0].detail[0].text[0];
+						try {
+							detail = fault.detail[0].text[0];
+						} catch (e) {
+							detail = '';
 						}
 
 						// console.error('Fault:', reason, detail);


### PR DESCRIPTION
On SOAP error, some cameras send a wrong SOAP structure (see Issue #73).
This PR permit to avoid having the error `"TypeError: Cannot read property '0' of undefined"`, but instead will try to read both `reason` and `detail` information, if one of them is wrong, we can still get the other.