### PR TITLE
Fix getNetworkInterfaces response returning a non-array

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -186,7 +186,7 @@ module.exports = function(Cam) {
 	/**
 	 * @callback Cam~GetNetworkInterfacesCallback
 	 * @property {?Error} error
-	 * @property {Array.<Cam~NetworkInterface>} network interfaces information
+	 * @property {Array.<Cam~NetworkInterface>} networkInterfaces Network interfaces information
 	 * @property {string} xml Raw SOAP response
 	 */
 
@@ -202,7 +202,10 @@ module.exports = function(Cam) {
 			this._envelopeFooter()
 		}, function(err, data, xml) {
 			if (!err) {
-				this.networkInterfaces = linerase(data).getNetworkInterfacesResponse;
+				this.networkInterfaces = linerase(data).getNetworkInterfacesResponse.networkInterfaces;
+				// networkInterfaces is an array of network interfaces, but linerase remove the array if there is only one element inside
+				// so we convert it back to an array
+				if (!Array.isArray(this.networkInterfaces)) {this.networkInterfaces = [this.networkInterfaces];}
 			}
 			if (callback) {
 				callback.call(this, err, this.networkInterfaces, xml);


### PR DESCRIPTION
when only one network inteface is returned.
The returned object is now the Array of network interfaces (as declared in the JSDoc) instead of an object containing the array.
**This breaks backward compatibility!**
Also breaks the test I added in the PR #144, depending on which PR is accepted first, I will add commit on this PR or the other.