### PR TITLE
Improve `setVideoEncoderConfiguration`.

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -107,6 +107,7 @@ module.exports = function(Cam) {
 	 * @property {string} $.token Token that uniquely refernces this configuration
 	 * @property {string} name User readable name.
 	 * @property {string} useCount Number of internal references currently using this configuration
+	 * @property {boolan} guaranteedFrameRate A value of true indicates that frame rate is a fixed value rather than an upper limit, and that the video encoder shall prioritize frame rate over all other adaptable configuration values such as bitrate. Default is false
 	 * @property {string} encoding Used video codec ('JPEG' | 'MPEG4' | 'H264' )
 	 * @property {object} resolution Configured video resolution
 	 * @property {number} resolution.width
@@ -121,7 +122,7 @@ module.exports = function(Cam) {
 	 * @property {string} H264.H264profile the H.264 profile
 	 * @property {object} [MPEG4] Optional element to configure Mpeg4 related parameters
 	 * @property {number} MPEG4.govLength Determines the interval in which the I-Frames will be coded.
-	 * @property {string} MPEG4.MPEG4profile the Mpeg4 profile
+	 * @property {string} MPEG4.mpeg4profile the Mpeg4 profile
 	 * @property {object} multicast
 	 * @property {string} multicast.address.type
 	 * @property {string} [multicast.address.IPv4Address]
@@ -133,14 +134,14 @@ module.exports = function(Cam) {
 	 */
 
 	/**
-	 * @callback Cam~VideoEncoderConfigurationCallback
+	 * @callback Cam~GetVideoEncoderConfigurationCallback
 	 * @property {?Error} error
 	 * @property {Cam~VideoEncoderConfiguration} videoEncoderConfiguration
 	 * @property {string} xml Raw SOAP response
 	 */
 
 	/**
-	 * @callback Cam~VideoEncoderConfigurationsCallback
+	 * @callback Cam~GetVideoEncoderConfigurationsCallback
 	 * @property {?Error} error
 	 * @property {Array.<Cam~VideoEncoderConfiguration>} videoEncoderConfigurations
 	 * @property {string} xml Raw SOAP response
@@ -150,7 +151,7 @@ module.exports = function(Cam) {
 	 * Get existing video encoder configuration by its token
 	 * If token is omitted tries first from #videoEncoderConfigurations array
 	 * @param {string} [token] Token of the requested video encoder configuration
-	 * @param {Cam~VideoEncoderConfigurationCallback} callback
+	 * @param {Cam~GetVideoEncoderConfigurationCallback} callback
 	 */
 	Cam.prototype.getVideoEncoderConfiguration = function(token, callback) {
 		if (callback === undefined) {
@@ -332,7 +333,7 @@ module.exports = function(Cam) {
 
 	/**
 	 * Get all existing video encoder configurations of a device
-	 * @param {Cam~VideoEncoderConfigurationsCallback} callback
+	 * @param {Cam~GetVideoEncoderConfigurationsCallback} callback
 	 */
 	Cam.prototype.getVideoEncoderConfigurations = function(callback) {
 		this._request({
@@ -354,36 +355,8 @@ module.exports = function(Cam) {
 
 	/**
 	 * Set the device video encoder configuration
-	 * @param {object} options
-	 * @param {string} [options.token] Token that uniquely references this configuration.
-	 * @param {string} [options.$.token] Token that uniquely references this configuration.
-	 * @param {string} [options.name] User readable name.
-	 * @param {number} [options.useCount] Number of internal references (read-only)
-	 * @param {string} [options.encoding] ( JPEG | H264 | MPEG4 )
-	 * @param {object} [options.resolution] Configured video resolution
-	 * @param {number} options.resolution.width Number of the columns of the Video image
-	 * @param {number} options.resolution.height Number of the lines of the Video image
-	 * @param {number} options.quality Relative value for the video quantizers and the quality of the video
-	 * @param {object} [options.rateControl] Optional element to configure rate control related parameters
-	 * @param {number} options.rateControl.frameRateLimit Maximum output framerate in fps
-	 * @param {number} options.rateControl.encodingInterval Interval at which images are encoded and transmitted  (A value of 1 means that every frame is encoded, a value of 2 means that every 2nd frame is encoded ...)
-	 * @param {number} options.rateControl.bitrateLimit the maximum output bitrate in kbps
-	 * @param {object} [options.MPEG4]
-	 * @param {number} options.MPEG4.govLength Determines the interval in which the I-Frames will be coded
-	 * @param {string} options.MPEG4.profile the Mpeg4 profile ( SP | ASP )
-	 * @param {object} [options.H264]
-	 * @param {number} options.H264.govLength Group of Video frames length
-	 * @param {string} options.H264.profile the H.264 profile ( Baseline | Main | Extended | High )
-	 * @param {object} [options.multicast]
-	 * @param {object|number} [options.multicast.address] The multicast address (if this address is set to 0 no multicast streaming is enaled)
-	 * @param {string} options.multicast.address.type Indicates if the address is an IPv4 or IPv6 address ( IPv4 | IPv6)
-	 * @param {string} [options.multicast.address.IPv4Address]
-	 * @param {string} [options.multicast.address.IPv6Address]
-	 * @param {number} [options.multicast.port] The RTP mutlicast destination port
-	 * @param {number} [options.multicast.TTL]
-	 * @param {boolean} [options.multicast.autoStart]
-	 * @param {string} options.sessionTimeout
-	 * @param {Cam~VideoEncoderConfigurationCallback} callback
+	 * @param {Cam~VideoEncoderConfiguration} options
+	 * @param {Cam~GetVideoEncoderConfigurationCallback} callback
 	 */
 	Cam.prototype.setVideoEncoderConfiguration = function(options, callback) {
 		if (!options.token && !(options.$ && options.$.token)) {
@@ -393,7 +366,7 @@ module.exports = function(Cam) {
 			service: 'media',
 			body: this._envelopeHeader() +
 			'<SetVideoEncoderConfiguration xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-				'<Configuration token = "' + (options.token || options.$.token) + '">' +
+				'<Configuration token = "' + (options.token || options.$.token) + '" ' + (options.guaranteedFrameRate !== undefined ? 'GuaranteedFrameRate="' + options.guaranteedFrameRate + '"' : '') + '>' +
 				( options.name ? '<Name xmlns="http://www.onvif.org/ver10/schema">' + options.name + '</Name>' : '' ) +
 				( options.useCount ? '<UseCount xmlns="http://www.onvif.org/ver10/schema">' + options.useCount + '</UseCount>' : '' ) +
 				( options.encoding ? '<Encoding xmlns="http://www.onvif.org/ver10/schema">' + options.encoding + '</Encoding>' : '' ) +
@@ -412,11 +385,11 @@ module.exports = function(Cam) {
 				( options.MPEG4 ?
 					'<MPEG4 xmlns="http://www.onvif.org/ver10/schema">' +
 					( options.MPEG4.govLength ? '<GovLength>' + options.MPEG4.govLength + '</GovLength>' : '' ) +
-					( options.MPEG4.profile ? '<MPEG4Profile>' + options.MPEG4.profile + '</MPEG4Profile>' : '') +
+					( options.MPEG4.mpeg4Profile ? '<Mpeg4Profile>' + options.MPEG4.mpeg4Profile + '</Mpeg4Profile>' : '') +
 				'</MPEG4>' : '') +
 				( options.H264 ? '<H264 xmlns="http://www.onvif.org/ver10/schema">' +
 					( options.H264.govLength ? '<GovLength>' + options.H264.govLength + '</GovLength>' : '' ) +
-					( options.H264.profile ? '<H264Profile>' + options.H264.profile + '</H264Profile>' : '' ) +
+					( options.H264.H264Profile ? '<H264Profile>' + options.H264.H264Profile + '</H264Profile>' : '' ) +
 				'</H264>' : '') +
 				( options.multicast ?
 					'<Multicast xmlns="http://www.onvif.org/ver10/schema">' +


### PR DESCRIPTION
Fix names in `setVideoEncoderConfiguration`.
Update JSDoc.

Rename following the ONVIF specs.
This also permit to `getVideoEncoderConfiguration`, modify the object returned then use it to `setVideoEncoderConfiguration`. Before that we had to convert `mpeg4Profile` and `H264Profile` keys to `profile`.

EDIT: this breaks backward compatibility, we may change this to try both `mpeg4Profile` and `profile` then both `H264Profile` and `profile`