### PR TITLE
Improve `setVideoEncoderConfigurationOptions` to return Arrays

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -325,7 +325,32 @@ module.exports = function(Cam) {
 			this._envelopeFooter()
 		}, function(err, data, xml) {
 			if (callback) {
-				callback.call(this, err, err ? null : linerase(data[0].getVideoEncoderConfigurationOptionsResponse[0].options), xml);
+				let dataOut = null;
+				if (!err) {
+					dataOut = linerase(data[0].getVideoEncoderConfigurationOptionsResponse[0].options);
+					// Convert back to Array the lists of 1 element that linerase converted to object
+					if (dataOut.H264) {
+						if (!Array.isArray(dataOut.H264.resolutionsAvailable)) {dataOut.H264.resolutionsAvailable = [dataOut.H264.resolutionsAvailable];}
+						if (!Array.isArray(dataOut.H264.H264ProfilesSupported)) {dataOut.H264.H264ProfilesSupported = [dataOut.H264.H264ProfilesSupported];}
+					}
+					if (dataOut.MPEG4) {
+						if (!Array.isArray(dataOut.MPEG4.resolutionsAvailable)) {dataOut.MPEG4.resolutionsAvailable = [dataOut.MPEG4.resolutionsAvailable];}
+						if (!Array.isArray(dataOut.MPEG4.mpeg4ProfilesSupported)) {dataOut.MPEG4.mpeg4ProfilesSupported = [dataOut.MPEG4.mpeg4ProfilesSupported];}
+					}
+					if (dataOut.JPEG && !Array.isArray(dataOut.JPEG.resolutionsAvailable)) {dataOut.JPEG.resolutionsAvailable = [dataOut.JPEG.resolutionsAvailable];}
+					if (dataOut.extension) {
+						if (dataOut.extension.H264) {
+							if (!Array.isArray(dataOut.extension.H264.resolutionsAvailable)) {dataOut.extension.H264.resolutionsAvailable = [dataOut.extension.H264.resolutionsAvailable];}
+							if (!Array.isArray(dataOut.extension.H264.H264ProfilesSupported)) {dataOut.extension.H264.H264ProfilesSupported = [dataOut.extension.H264.H264ProfilesSupported];}
+						}
+						if (dataOut.extension.MPEG4) {
+							if (!Array.isArray(dataOut.extension.MPEG4.resolutionsAvailable)) {dataOut.extension.MPEG4.resolutionsAvailable = [dataOut.extension.MPEG4.resolutionsAvailable];}
+							if (!Array.isArray(dataOut.extension.MPEG4.mpeg4ProfilesSupported)) {dataOut.extension.MPEG4.mpeg4ProfilesSupported = [dataOut.extension.MPEG4.mpeg4ProfilesSupported];}
+						}
+						if (dataOut.extension.JPEG && !Array.isArray(dataOut.extension.JPEG.resolutionsAvailable)) {dataOut.extension.JPEG.resolutionsAvailable = [dataOut.extension.JPEG.resolutionsAvailable];}
+					}
+				}
+				callback.call(this, err, err ? null : dataOut, xml);
 			}
 		}.bind(this));
 	};


### PR DESCRIPTION
I have a HIK Vision camera that returns only one mpeg4ProfileSupported, which is converted to a string instead of an Array by the xml parser