### PR TITLE
Improve `getAudioEncoderConfigurationOptions`.

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -526,30 +526,70 @@ module.exports = function(Cam) {
 	};
 
 	/**
+	 * @typedef {object} Cam~IntItems
+	 * @property {Array.<number>} items
+	 */
+
+	/**
+	 * @typedef {object} Cam~AudioEncoderConfigurationOption
+	 * @property {object} encoding The enoding used for audio data (either G.711, G.726 or AAC) - enum { 'G711', 'G726', 'AAC' }
+	 * @property {Cam~IntItems} bitrateList List of supported bitrates in kbps for the specified Encoding
+	 * @property {Cam~IntItems} sampleRateList List of supported Sample Rates in kHz for the specified Encoding
+	 */
+
+	/**
+	 * @typedef {object} Cam~AudioEncoderConfigurationOptions
+	 * @property {Array.<Cam~AudioEncoderConfigurationOption>} options list of supported AudioEncoderConfigurations
+	 */
+
+	/**
+	 * @callback Cam~GetAudioEncoderConfigurationOptionsCallback
+	 * @property {?Error} error
+	 * @property {Cam~AudioEncoderConfigurationOptions} audioEncoderConfigurationOptions This message contains the audio encoder configuration options. If a audio encoder configuration is specified, the options shall concern that particular configuration. If a media profile is specified, the options shall be compatible with that media profile. If no tokens are specified, the options shall be considered generic for the device.
+	 * @property {string} xml Raw SOAP response
+	 */
+
+	/**
 	 * Get existing audio encoder configuration options by its token
 	 * If token is omitted tries first from #audioEncoderConfigurations array
 	 * @param {string} [token] Token of the requested audio encoder configuration
-	 * @param {Cam~AudioEncoderConfigurationOptionsCallback} callback
+	 * @param {Cam~GetAudioEncoderConfigurationOptionsCallback} callback
 	 */
-	Cam.prototype.getAudioEncoderConfigurationOptions = function(token, callback) {
+	Cam.prototype.getAudioEncoderConfigurationOptions = function(options, callback) {
 		if (callback === undefined) {
-			callback = token;
+			callback = options;
 			if (this.audioEncoderConfigurations && this.audioEncoderConfigurations[0]) {
-				token = this.audioEncoderConfigurations[0].$.token;
+				options = { configurationToken: this.audioEncoderConfigurations[0].$.token };
 			} else {
 				return callback(new Error('No audio encoder configuration token is present!'));
 			}
+		} else if (typeof options == "string") { // For backward compatibility
+			options = { configurationToken: options };
+		} else if (!(options && (options.configurationToken || options.profileToken))) {
+			return callback(new Error("'options' must have one or both 'configurationToken' or 'profileToken'"));
 		}
 		this._request({
 			service: 'media'
 			, body: this._envelopeHeader() +
-			'<GetAudioEncoderConfigurationOptions xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-				'<ConfigurationToken>' + token + '</ConfigurationToken>' +
-			'</GetAudioEncoderConfigurationOptions>' +
+			(
+				'<GetAudioEncoderConfigurationOptions xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+				( options.configurationToken ? '<ConfigurationToken>' + options.configurationToken + '</ConfigurationToken>' : "" ) +
+				( options.profileToken ? '<ProfileToken>' + options.profileToken + '</ProfileToken>' : "" ) +
+				'</GetAudioEncoderConfigurationOptions>'
+			) +
 			this._envelopeFooter()
 		}, function(err, data, xml) {
 			if (callback) {
-				callback.call(this, err, err ? null : linerase(data[0].getAudioEncoderConfigurationOptionsResponse[0].options), xml);
+				if (!err) {
+					data = linerase(data[0].getAudioEncoderConfigurationOptionsResponse[0].options);
+					// Convert simple objects back to Arrays
+					if (!Array.isArray(data.options)) { data.options = [data.options]; }
+					data.options.forEach(function(option) {
+						if (!Array.isArray(option.bitrateList.items)) { option.bitrateList.items = [option.bitrateList.items]; }
+						if (!Array.isArray(option.sampleRateList.items)) { option.sampleRateList.items = [option.sampleRateList.items]; }
+					})
+				}
+				callback.call(this, err, err ? null : data, xml);
 			}
 		}.bind(this));
 	};

--- a/test/media.coffee
+++ b/test/media.coffee
@@ -161,12 +161,39 @@ describe 'Media', () ->
     it 'should return a configuration options for the first token in #audioEncoderConfigurations array', (done) ->
       cam.getAudioEncoderConfigurationOptions (err, res) ->
         assert.equal err, null
-        assert.ok res.bitrateList
+        assert.ok res.options
+        assert.ok Array.isArray(res.options)
+        assert.ok Array.isArray(res.options[0].bitrateList.items)     # Check that bitrateList.items is an Array while containing only one element
+        assert.ok res.options[0].bitrateList.items.length, 1
+        assert.ok Array.isArray(res.options[1].sampleRateList.items)  # Same for sampleRateList.items
+        assert.ok res.options[0].sampleRateList.items.length, 1
         done()
     it 'should return a configuration options for the named token as a first argument', (done) ->
       cam.getAudioEncoderConfigurationOptions cam.audioEncoderConfigurations[0].$.token, (err, res) ->
         assert.equal err, null
-        assert.ok res.bitrateList
+        assert.ok res.options
+        done()
+    it 'should return a configuration options for the ConfigurationToken token in an object as a first argument', (done) ->
+      cam.getAudioEncoderConfigurationOptions {
+        configurationToken: cam.audioEncoderConfigurations[0].$.token
+      }, (err, res) ->
+        assert.equal err, null
+        assert.ok res.options
+        done()
+    it 'should return a configuration options for the ProfileToken token in an object as a first argument', (done) ->
+      cam.getAudioEncoderConfigurationOptions {
+        profileToken: 'profileToken'
+      }, (err, res) ->
+        assert.equal err, null
+        assert.ok res.options
+        done()
+    it 'should return a configuration options for both ConfigurationToken and ProfileToken as a first argument', (done) ->
+      cam.getAudioEncoderConfigurationOptions {
+        configurationToken: cam.audioEncoderConfigurations[0].$.token,
+        profileToken: 'profileToken'
+      }, (err, res) ->
+        assert.equal err, null
+        assert.ok res.options
         done()
 
   describe 'setAudioEncoderConfiguration', () ->

--- a/test/serverMockup/media.GetAudioEncoderConfigurationOptions.xml
+++ b/test/serverMockup/media.GetAudioEncoderConfigurationOptions.xml
@@ -13,19 +13,32 @@
         <SOAP-ENV:Body>
                 <trt:GetAudioEncoderConfigurationOptionsResponse>
                         <trt:Options>
-                            <tt:Encoding>
-                                G711
-                            </tt:Encoding>
-                            <tt:BitrateList>
-                                <tt:List>5</tt:List>
-                                <tt:List>10</tt:List>
-                                <tt:List>15</tt:List>
-                            </tt:BitrateList>
-                            <tt:SampleRateList>
-                                <tt:List>5</tt:List>
-                                <tt:List>10</tt:List>
-                                <tt:List>15</tt:List>
-                            </tt:SampleRateList>                                
+                                <tt:Options>
+                                        <tt:Encoding>
+                                                G711
+                                        </tt:Encoding>
+                                        <tt:BitrateList>
+                                                <tt:Items>5</tt:Items>
+                                        </tt:BitrateList>
+                                        <tt:SampleRateList>
+                                                <tt:Items>5</tt:Items>
+                                                <tt:Items>10</tt:Items>
+                                                <tt:Items>15</tt:Items>
+                                        </tt:SampleRateList>
+                                </tt:Options>
+                                <tt:Options>
+                                        <tt:Encoding>
+                                                G711
+                                        </tt:Encoding>
+                                        <tt:BitrateList>
+                                                <tt:Items>5</tt:Items>
+                                                <tt:Items>10</tt:Items>
+                                                <tt:Items>15</tt:Items>
+                                        </tt:BitrateList>
+                                        <tt:SampleRateList>
+                                                <tt:Items>5</tt:Items>
+                                        </tt:SampleRateList>
+                                </tt:Options>
                         </trt:Options>
                 </trt:GetAudioEncoderConfigurationOptionsResponse>
         </SOAP-ENV:Body>


### PR DESCRIPTION
Permit to get an `AudioEncoderConfigurationOption` with either a `ConfigurationToken`, a `ProfileToken` or both as first argument.
Update JSDoc.

**This breaks backward compatibility**. But I wonder, I updated the response XML file because with the cameras I have (Samsung and HIK Vision), it's very different. First, there are `tt:Options` tags inside the `trt:Options` tag, second, the elements in lists are not `tt:List` but `tt:Items`. Did the structure change over years ? Are there cameras still responding the old way ? If that's the case, we will have to convert one structure into the other.