### PR TITLE
Bugfix/fix uncaught exception while pulling events

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -118,7 +118,7 @@ module.exports = function(Cam) {
 		}
 
 		try {
-			subscriptionId = this.events.subscription.subscriptionReference.referenceParameters.subscriptionId
+			subscriptionId = this.events.subscription.subscriptionReference.referenceParameters.subscriptionId;
 		} catch (e) {
 			subscriptionId = null;
 		}
@@ -126,7 +126,7 @@ module.exports = function(Cam) {
 		let sendXml = this._envelopeHeader(true);
 
 		if (!subscriptionId) {
-			sendXml += '<a:To>' + urlAddress.href + '</a:To>'
+			sendXml += '<a:To>' + urlAddress.href + '</a:To>';
 		} else {
 			// Axis Cameras use a PullPoint URL and the Subscription ID
 			sendXml += '<a:To mustUnderstand="1">' + urlAddress.href + '</a:To>' +
@@ -137,7 +137,7 @@ module.exports = function(Cam) {
 				'<Renew xmlns="http://docs.oasis-open.org/wsn/b-2">' +
 					'<TerminationTime>PT60S</TerminationTime>' +
 				'</Renew>' +
-			this._envelopeFooter()
+			this._envelopeFooter();
 		this._request({
 			url: urlAddress,
 			body: sendXml
@@ -149,7 +149,7 @@ module.exports = function(Cam) {
 		}.bind(this));
 	};
 
-	
+
 
 	/**
 	 * @typedef {object} Cam~Event
@@ -189,7 +189,7 @@ module.exports = function(Cam) {
 		}
 
 		try {
-			subscriptionId = this.events.subscription.subscriptionReference.referenceParameters.subscriptionId
+			subscriptionId = this.events.subscription.subscriptionReference.referenceParameters.subscriptionId;
 		} catch (e) {
 			subscriptionId = null;
 		}
@@ -197,7 +197,7 @@ module.exports = function(Cam) {
 		let sendXml = this._envelopeHeader(true);
 
 		if (!subscriptionId) {
-			sendXml += '<a:To>' + urlAddress.href + '</a:To>'
+			sendXml += '<a:To>' + urlAddress.href + '</a:To>';
 		} else {
 			// Axis Cameras use a PullPoint URL and the Subscription ID
 			sendXml += '<a:To mustUnderstand="1">' + urlAddress.href + '</a:To>' +
@@ -236,7 +236,7 @@ module.exports = function(Cam) {
 		}
 
 		try {
-			subscriptionId = this.events.subscription.subscriptionReference.referenceParameters.subscriptionId
+			subscriptionId = this.events.subscription.subscriptionReference.referenceParameters.subscriptionId;
 		} catch (e) {
 			subscriptionId = null;
 		}
@@ -244,7 +244,7 @@ module.exports = function(Cam) {
 		let sendXml = this._envelopeHeader(true);
 
 		if (!subscriptionId) {
-			sendXml += '<a:To>' + urlAddress.href + '</a:To>'
+			sendXml += '<a:To>' + urlAddress.href + '</a:To>';
 		} else {
 			// Axis Cameras use a PullPoint URL and the Subscription ID
 			sendXml += '<a:To mustUnderstand="1">' + urlAddress.href + '</a:To>' +
@@ -286,7 +286,7 @@ module.exports = function(Cam) {
 		if (this.eventEmitter.listeners('event').length) { // check for event listeners, if zero, stop pulling
 			this.events.timeout = this.events.timeout || 30000; // setting timeout
 			this.events.messageLimit = this.events.messageLimit || 10; // setting message limit
-			if (!this.events.terminationTime || (this.events.terminationTime < Date.now() + this.events.timeout)) {
+			if (!this.events.subscription || !this.events.terminationTime || (this.events.terminationTime < Date.now() + this.events.timeout)) {
 				// if there is no pull-point subscription or it will be dead soon, create new
 				this.createPullPointSubscription(this._eventPull.bind(this));
 			} else {
@@ -302,6 +302,7 @@ module.exports = function(Cam) {
 	/**
 	 * Event loop for pullMessages request
 	 * @private
+	 * @throws {Error} {@link Cam#events.subscription} must exists
 	 */
 	Cam.prototype._eventPull = function() {
 		if (this.eventEmitter.listeners('event').length) { // check for event listeners, if zero, stop pulling
@@ -330,7 +331,7 @@ module.exports = function(Cam) {
 						if (!err) {
 							this.events.terminationTime = _terminationTime(data);
 						}
-					})
+					});
 				}
 				this._eventRequest();
 			}.bind(this));


### PR DESCRIPTION
Using Onvif events in a node app leads to infrequent unhandled exeptions as follows:

```
Error: You should create pull-point subscription first!
    at Cam.pullMessages (/home/pi/backend/node_modules/onvif/lib/events.js:188:10)
    at Cam._eventPull (/home/pi/backend/node_modules/onvif/lib/events.js:308:9)
    at Cam.<anonymous> (/home/pi/backend/node_modules/onvif/lib/events.js:100:13)
    at parseSOAPString (/home/pi/backend/node_modules/onvif/lib/utils.js:108:3)
    at IncomingMessage.<anonymous> (/home/pi/backend/node_modules/onvif/lib/cam.js:270:4)
    at IncomingMessage.emit (events.js:327:22)
    at IncomingMessage.EventEmitter.emit (domain.js:483:12)
    at endReadableNT (_stream_readable.js:1220:12)
    at processTicksAndRejections (internal/process/task_queues.js:84:21)
```

Changes:
- In line 289 an additinal check regarding events.subscription is introduced, since `pullMessages` will throw otherwise.
- Added several missing semicolons.