### PR TITLE
Review of Profile T and Media2 API changes requested

### DIFF
--- a/example7.js
+++ b/example7.js
@@ -8,7 +8,9 @@
  * This DOES NOT use ONVIF Discovery. This softweare tries each IP address in
  * turn which allows it to work on networks where ONVIF Discovery does not work
  * (eg on Layer 3 routed networks)
- *
+ * 
+ * EXAMPLE USING PROMISES by convering callbacks into Promises
+ * You can do this in NodeJS or using the Bluebird NPM
  */
 
 var IP_RANGE_START = '192.168.1.1',
@@ -68,7 +70,7 @@ ipList.forEach(function(ipEntry) {
 					videoResults += "Profile: Name=" + profile.name + " Token=" + profile.$.token + " VideoSource=" + profile.videoSourceConfiguration.name + "\r\n"
 
 					try {
-						videoResults += "HTTP JPEG URL  ";
+						videoResults += "SNAPSHOT URL   ";
 						let snapshotUri = await promiseGetSnapshotUri(
 							{
 								profileToken: profile.$.token,
@@ -126,7 +128,7 @@ ipList.forEach(function(ipEntry) {
 					}
 
 					try {
-						videoResults += "HTTP           ";
+						videoResults += "RTSP HTTP      ";
 						stream = await promiseGetStreamUri(
 							{
 								profileToken: profile.$.token,

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -727,9 +727,7 @@ Cam.prototype.getServices = function(includeCapability, callback) {
 				 * @name Cam#uri
 				 * @property {url} [PTZ]
 				 * @property {url} [media]
-				* @property {
-				url
-			} [media2]
+				 * @property {url} [media2]
 				 * @property {url} [imaging]
 				 * @property {url} [events]
 				 * @property {url} [device]

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -716,6 +716,10 @@ Cam.prototype.getServices = function(includeCapability, callback) {
 			 * @type {Cam~Services}
 			 */
 			this.services = linerase(data).getServicesResponse.service;
+
+			// ONVIF Profile T introduced Media2 (ver20) so cameras from around 2020/2021 will have
+			// two media entries in the ServicesResponse, one for Media (ver10/media) and one for Media2 (ver20/media)
+			// This is so that existing VMS software can still access the video via the orignal ONVIF Media API
 			// fill Cam#uri property
 			if (!this.uri) {
 				/**
@@ -723,6 +727,9 @@ Cam.prototype.getServices = function(includeCapability, callback) {
 				 * @name Cam#uri
 				 * @property {url} [PTZ]
 				 * @property {url} [media]
+				* @property {
+				url
+			} [media2]
 				 * @property {url} [imaging]
 				 * @property {url} [events]
 				 * @property {url} [device]
@@ -732,10 +739,12 @@ Cam.prototype.getServices = function(includeCapability, callback) {
 			this.media2Support = false;
 			this.services.forEach((service) => {
 				let namespaceSplitted = service.namespace.split('.org/')[1].split('/');
-				this.uri[namespaceSplitted[1]] = this._parseUrl(service.XAddr);
+				// special case for Media and Media2 where cameras supporting Profile S and Profile T (2020/2021 models) have two media services
 				if (namespaceSplitted[1] == 'media' && namespaceSplitted[0] == 'ver20') {
 					this.media2Support = true;
+					namespaceSplitted[1] = 'media2';
 				}
+				this.uri[namespaceSplitted[1]] = this._parseUrl(service.XAddr);
 			});
 		}
 		if (callback) {

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -736,13 +736,20 @@ Cam.prototype.getServices = function(includeCapability, callback) {
 			}
 			this.media2Support = false;
 			this.services.forEach((service) => {
-				let namespaceSplitted = service.namespace.split('.org/')[1].split('/');
-				// special case for Media and Media2 where cameras supporting Profile S and Profile T (2020/2021 models) have two media services
-				if (namespaceSplitted[1] == 'media' && namespaceSplitted[0] == 'ver20') {
-					this.media2Support = true;
-					namespaceSplitted[1] = 'media2';
+				// Look for services with a namespaces and XAddr values
+				if (service.hasOwnProperty('namespace') && service.hasOwnProperty('XAddr')) {
+					// Only parse ONVIF namespaces. Axis cameras return Axis namespaces in GetServices
+					let parsedNamespace = url.parse(service.namespace);
+					if (parsedNamespace.hostname === 'www.onvif.org') {
+						let namespaceSplitted = parsedNamespace.path.substring(1).split('/'); // remove leading Slash, then split
+						// special case for Media and Media2 where cameras supporting Profile S and Profile T (2020/2021 models) have two media services
+						if (namespaceSplitted[1] == 'media' && namespaceSplitted[0] == 'ver20') {
+							this.media2Support = true;
+							namespaceSplitted[1] = 'media2';
+						}
+						this.uri[namespaceSplitted[1]] = this._parseUrl(service.XAddr);
+					}
 				}
-				this.uri[namespaceSplitted[1]] = this._parseUrl(service.XAddr);
 			});
 		}
 		if (callback) {

--- a/lib/media.js
+++ b/lib/media.js
@@ -914,17 +914,20 @@ module.exports = function(Cam) {
 	 */
 	Cam.prototype.getProfiles = function(callback) {
 		if (this.media2Support) {
-			// Newer Media2 (media20) request
+			// Profile T request using Media2
 			// The reply is in a different format to the old API so we convert the data from the new API to the old structure
 			// for backwards compatibility with existing users of this library
 			this._request({
-				service: 'media'
+				service: 'media2'
 				, body: this._envelopeHeader() +
 					'<GetProfiles xmlns="http://www.onvif.org/ver20/media/wsdl">' +
 					'<Type>All</Type>' +
 					'</GetProfiles>' +
 					this._envelopeFooter()
 			}, function(err, data, xml) {
+				// Slight difference in Media1 and Media2 reply XML
+				// Generate a reply that looks like a Media1 reply for existing library users
+
 				if (!err) {
 					/**
 					 * Array of all device profiles
@@ -966,7 +969,7 @@ module.exports = function(Cam) {
 			}.bind(this));
 
 		} else {
-			// Original ONVIF Media (Media1) support
+			// Original ONVIF Media support (used in Profile S)
 			this._request({
 				service: 'media'
 				, body: this._envelopeHeader() +
@@ -1076,18 +1079,38 @@ module.exports = function(Cam) {
 	 */
 	Cam.prototype.getSnapshotUri = function(options, callback) {
 		if (callback === undefined) { callback = options; options = {}; }
-		this._request({
-			service: 'media'
-			, body: this._envelopeHeader() +
-			'<GetSnapshotUri xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
-			'</GetSnapshotUri>' +
-			this._envelopeFooter()
-		}, function(err, data, xml) {
-			if (callback) {
-				callback.call(this, err, err ? null : linerase(data).getSnapshotUriResponse.mediaUri, xml);
-			}
-		}.bind(this));
+		if (this.media2Support) {
+			// Profile T request using Media2
+			this._request({
+				service: 'media2'
+				, body: this._envelopeHeader() +
+					// Note - Namespace difference for Media2
+					'<GetSnapshotUri xmlns="http://www.onvif.org/ver20/media/wsdl">' +
+						'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+					'</GetSnapshotUri>' +
+					this._envelopeFooter()
+			}, function(err, data, xml) {
+				if (callback) {
+					// Slight difference in Media1 and Media2 reply XML
+					// Generate a reply that looks like a Media1 reply for existing library users
+					callback.call(this, err, err ? null : { uri: linerase(data).getSnapshotUriResponse.uri }, xml);
+				}
+			}.bind(this));
+		} else {
+			// Original ONVIF Specification for Media (used in Profile S)
+			this._request({
+				service: 'media'
+				, body: this._envelopeHeader() +
+				'<GetSnapshotUri xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+					'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+				'</GetSnapshotUri>' +
+				this._envelopeFooter()
+			}, function(err, data, xml) {
+				if (callback) {
+					callback.call(this, err, err ? null : linerase(data).getSnapshotUriResponse.mediaUri, xml);
+				}
+			}.bind(this));
+		}
 	};
 
 	/**

--- a/lib/media.js
+++ b/lib/media.js
@@ -913,26 +913,81 @@ module.exports = function(Cam) {
 	 * @param {Cam~GetProfilesCallback} [callback]
 	 */
 	Cam.prototype.getProfiles = function(callback) {
-		this._request({
-			service: 'media'
-			, body: this._envelopeHeader() +
-			'<GetProfiles xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
-			this._envelopeFooter()
-		}, function(err, data, xml) {
-			if (!err) {
-				/**
-				 * Array of all device profiles
-				 * @name Cam#profiles
-				 * @type {Array<Cam~Profile>}
-				 */
-				this.profiles = data[0]['getProfilesResponse'][0]['profiles'].map(function(profile) {
-					return linerase(profile);
-				});
-			}
-			if (callback) {
-				callback.call(this, err, this.profiles, xml);
-			}
-		}.bind(this));
+		if (this.media2Support) {
+			// Newer Media2 (media20) request
+			// The reply is in a different format to the old API so we convert the data from the new API to the old structure
+			// for backwards compatibility with existing users of this library
+			this._request({
+				service: 'media'
+				, body: this._envelopeHeader() +
+					'<GetProfiles xmlns="http://www.onvif.org/ver20/media/wsdl">' +
+					'<Type>All</Type>' +
+					'</GetProfiles>' +
+					this._envelopeFooter()
+			}, function(err, data, xml) {
+				if (!err) {
+					/**
+					 * Array of all device profiles
+					 * @name Cam#profiles
+					 * @type {Array<Cam~Profile>}
+					 */
+					this.profiles = data[0]['getProfilesResponse'][0]['profiles'].map(function(profile) {
+						let tmp = linerase(profile);
+						let newProfile = {};
+						newProfile.$ = tmp.$; // copy Profile Token
+						newProfile.name = tmp.name;
+						// Media2 Spec says there will be these some or all of these configuration entities
+						// Video source configuration
+						// Audio source configuration
+						// Video encoder configuration
+						// Audio encoder configuration
+						// PTZ configuration
+						// Video analytics configuration 
+						// Metadata configuration
+						// Audio output configuration
+						// Audio decoder configuration 
+						if (tmp.configurations.videoSource) {newProfile.videoSourceConfiguration = tmp.configurations.videoSource;}
+						if (tmp.configurations.audioSource) {newProfile.audioSourceConfiguration = tmp.configurations.audioSource;}
+						if (tmp.configurations.videoEncoder) {newProfile.videoEncoderConfiguration = tmp.configurations.videoEncoder;}
+						if (tmp.configurations.audioEncoder) {newProfile.audioEncoderConfiguration = tmp.configurations.audioEncoder;}
+						if (tmp.configurations.PTZ) {newProfile.PTZConfiguration = tmp.configurations.PTZ;}
+						if (tmp.configurations.analytics) {newProfile.analyticsConfiguration = tmp.configurations.analytics;}
+						if (tmp.configurations.metadata) {newProfile.metadataConfiguration = tmp.configurations.metadata;}
+						if (tmp.configurations.audioOutput) {newProfile.audioOutputConfiguration = tmp.configurations.audioOutput;}
+						if (tmp.configurations.audioOutput) {newProfile.audioDecoderConfiguration = tmp.configurations.audioDecoder;}
+
+						// TODO - Add Audio
+						return newProfile;
+					});
+				}
+				if (callback) {
+					callback.call(this, err, this.profiles, xml);
+				}
+			}.bind(this));
+
+		} else {
+			// Original ONVIF Media (Media1) support
+			this._request({
+				service: 'media'
+				, body: this._envelopeHeader() +
+				'<GetProfiles xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+				this._envelopeFooter()
+			}, function(err, data, xml) {
+				if (!err) {
+					/**
+					 * Array of all device profiles
+					 * @name Cam#profiles
+					 * @type {Array<Cam~Profile>}
+					 */
+					this.profiles = data[0]['getProfilesResponse'][0]['profiles'].map(function(profile) {
+						return linerase(profile);
+					});
+				}
+				if (callback) {
+					callback.call(this, err, this.profiles, xml);
+				}
+			}.bind(this));
+		}
 	};
 
 	/**

--- a/lib/media.js
+++ b/lib/media.js
@@ -1051,24 +1051,55 @@ module.exports = function(Cam) {
 	 */
 	Cam.prototype.getStreamUri = function(options, callback) {
 		if (callback === undefined) { callback = options; options = {};	}
-		this._request({
-			service: 'media'
-			, body: this._envelopeHeader() +
-			'<GetStreamUri xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-				'<StreamSetup>' +
-					'<Stream xmlns="http://www.onvif.org/ver10/schema">' + (options.stream || 'RTP-Unicast') + '</Stream>' +
-					'<Transport xmlns="http://www.onvif.org/ver10/schema">' +
-						'<Protocol>' + (options.protocol || 'RTSP') + '</Protocol>' +
-					'</Transport>' +
-				'</StreamSetup>' +
-				'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
-			'</GetStreamUri>' +
-			this._envelopeFooter()
-		}, function(err, data, xml) {
-			if (callback) {
-				callback.call(this, err, err ? null : linerase(data).getStreamUriResponse.mediaUri, xml);
-			}
-		}.bind(this));
+		if (this.media2Support) {
+			// Permitted values for options.protocol are :-
+			//   RtspUnicast - RTSP streaming RTP via UDP Unicast.
+			//   RtspMulticast - RTSP streaming RTP via UDP Multicast.
+			//   RTSP - RTSP streaming RTP over TCP.
+			//   RtspOverHttp - Tunneling both the RTSP control channel and the RTP stream over HTTP or HTTPS. 
+			let protocol = options.protocol || 'RTSP';
+
+			// For backwards compatibility this function will convert Media1 Stream and Transport Protocol to a Media2 protocol
+			let stream = options.stream || 'RTP-Unicast';
+			if (protocol == 'HTTP') {protocol = 'RtspOverHttp';}
+			if (protocol == 'UDP' && stream == "RTP-Unicast") {protocol = 'RtspUnicast';}
+			if (protocol == 'UDP' && stream == "RTP-Multicast") {protocol = 'RtspMulticast';}
+
+			// Profile T request using Media2
+			this._request({
+				service: 'media2'
+				, body: this._envelopeHeader() +
+					'<GetStreamUri xmlns="http://www.onvif.org/ver20/media/wsdl">' +
+					'<Protocol>' + protocol + '</Protocol>' +
+					'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+					'</GetStreamUri>' +
+					this._envelopeFooter()
+			}, function(err, data, xml) {
+				if (callback) {
+					callback.call(this, err, err ? null : linerase(data).getStreamUriResponse, xml);
+				}
+			}.bind(this));
+		} else {
+			// Original ONVIF Specification for Media (used in Profile S)
+			this._request({
+				service: 'media'
+				, body: this._envelopeHeader() +
+				'<GetStreamUri xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+					'<StreamSetup>' +
+						'<Stream xmlns="http://www.onvif.org/ver10/schema">' + (options.stream || 'RTP-Unicast') + '</Stream>' +
+						'<Transport xmlns="http://www.onvif.org/ver10/schema">' +
+							'<Protocol>' + (options.protocol || 'RTSP') + '</Protocol>' +
+						'</Transport>' +
+					'</StreamSetup>' +
+					'<ProfileToken>' + (options.profileToken || this.activeSource.profileToken) + '</ProfileToken>' +
+				'</GetStreamUri>' +
+				this._envelopeFooter()
+			}, function(err, data, xml) {
+				if (callback) {
+					callback.call(this, err, err ? null : linerase(data).getStreamUriResponse.mediaUri, xml);
+				}
+			}.bind(this));
+		}
 	};
 
 	/**

--- a/lib/ptz.js
+++ b/lib/ptz.js
@@ -455,19 +455,22 @@ module.exports = function(Cam) {
 	 * @param {number} [options.x=0] pan velocity, float within 0 to 1
 	 * @param {number} [options.y=0] tilt velocity, float within 0 to 1
 	 * @param {number} [options.zoom=0] zoom velocity, float within 0 to 1
+	 * @param {boolean} [options.onlySendPanTilt] Only send the Pan and Tilt values in the ONVIF XML. Zoom not sent in the XML
+	 * @param {boolean} [options.onlySendZoom] Only send the Zoom values in the ONVIF XML. PanTilt not sent in the XML
+	 * Somy cameras do not accept X and Y and Zoom all at the same time
 	 * @param {number} [options.timeout=Infinity] timeout in milliseconds
 	 * @param {Cam~RequestCallback} callback
 	 */
 	Cam.prototype.continuousMove = function (options, callback) {
 		callback = callback ? callback.bind(this) : function () { };
-		// Due to some glitches in testing cam forcibly set undefined move parameters to zero
+		// Due to some glitches in testing cam, forcibly set undefined move parameters to zero
 		options.x = options.x || 0;
 		options.y = options.y || 0;
 		options.zoom = options.zoom || 0;
 
-		// But if we have set onlySendXY or onlySendZoom then don't send the other values
-		if (options.onlySendXY) delete options.zoom;
-		if (options.onlySendZ) { delete options.x; delete options.y; }
+		// But there is one Sony camera that does not work when Pan and Tilt and Zoom all all sent at the same time. So add a workaround to only send Pan/Tilt OR only send Zoom in the ONVIF XML
+		if (options.onlySendPanTilt) delete options.zoom;
+		if (options.onlySendZoom) { delete options.x; delete options.y; }
 
 		this._request({
 			service: 'ptz'

--- a/lib/ptz.js
+++ b/lib/ptz.js
@@ -458,12 +458,17 @@ module.exports = function(Cam) {
 	 * @param {number} [options.timeout=Infinity] timeout in milliseconds
 	 * @param {Cam~RequestCallback} callback
 	 */
-	Cam.prototype.continuousMove = function(options, callback) {
-		callback = callback ? callback.bind(this) : function() {};
+	Cam.prototype.continuousMove = function (options, callback) {
+		callback = callback ? callback.bind(this) : function () { };
 		// Due to some glitches in testing cam forcibly set undefined move parameters to zero
 		options.x = options.x || 0;
 		options.y = options.y || 0;
 		options.zoom = options.zoom || 0;
+
+		// But if we have set onlySendXY or onlySendZoom then don't send the other values
+		if (options.onlySendXY) delete options.zoom;
+		if (options.onlySendZ) { delete options.x; delete options.y; }
+
 		this._request({
 			service: 'ptz'
 			, body: this._envelopeHeader() +

--- a/test/common.coffee
+++ b/test/common.coffee
@@ -96,7 +96,8 @@ describe 'Common functions', () ->
       cam.connect (err) ->
         assert.equal err, null
         assert.ok cam.capabilities
-        assert.ok cam.uri.ptz
+        if synthTest
+          assert.ok cam.uri.ptz
         assert.ok cam.uri.media
         assert.ok cam.videoSources
         assert.ok cam.profiles
@@ -125,28 +126,29 @@ describe 'Common functions', () ->
       }, (err) ->
         assert.notEqual err, null
         done()
-    it 'should set system date and time', (done) ->
-      cam.setSystemDateAndTime {
-        dateTimeType: 'Manual'
-        dateTime: new Date()
-        daylightSavings: true
-        timezone: 'MSK'
-      }, (err, data) ->
-        assert.equal err, null
-        assert.ok (data instanceof Date)
-        done()
     if synthTest
-      it 'should return an error when SetSystemDateAndTime message returns error', (done) ->
-        serverMockup.conf.bad = true
+      it 'should set system date and time', (done) ->
         cam.setSystemDateAndTime {
           dateTimeType: 'Manual'
           dateTime: new Date()
           daylightSavings: true
           timezone: 'MSK'
-        }, (err) ->
-          assert.notEqual err, null
-          delete serverMockup.conf.bad
+        }, (err, data) ->
+          assert.equal err, null
+          assert.ok (data instanceof Date)
           done()
+      if synthTest
+        it 'should return an error when SetSystemDateAndTime message returns error', (done) ->
+          serverMockup.conf.bad = true
+          cam.setSystemDateAndTime {
+            dateTimeType: 'Manual'
+            dateTime: new Date()
+            daylightSavings: true
+            timezone: 'MSK'
+          }, (err) ->
+            assert.notEqual err, null
+            delete serverMockup.conf.bad
+            done()
 
   describe 'getHostname', () ->
     it 'should return device name', (done) ->
@@ -224,8 +226,12 @@ describe 'Common functions', () ->
     it 'should return a service capabilities object and also set them into #serviceCapabilities property', (done) ->
       cam.getServiceCapabilities (err, data) ->
         assert.equal err, null
-        assert.ok ['network', 'security', 'system', 'auxiliaryCommands'].every (prop) ->
-          data[prop]
+        if synthTest
+          assert.ok ['network', 'security', 'system', 'auxiliaryCommands'].every (prop) ->
+            data[prop]
+        else
+          assert.ok ['network', 'security', 'system'].every (prop) ->
+            data[prop]
         assert.equal cam.serviceCapabilities, data
         done()
 
@@ -332,11 +338,12 @@ describe 'Common functions', () ->
           done() if not (--cou)
 
   describe 'systemReboot', () ->
-    it 'should return a server message', (done) ->
-      cam.systemReboot (err, data) ->
-        assert.equal err, null
-        assert.equal typeof data, 'string'
-        done()
+    if synthTest
+      it 'should return a server message', (done) ->
+        cam.systemReboot (err, data) ->
+          assert.equal err, null
+          assert.equal typeof data, 'string'
+          done()
 
   describe 'EventEmitter', () ->
     onEvent = null

--- a/test/device.coffee
+++ b/test/device.coffee
@@ -68,9 +68,9 @@ describe 'Device', () ->
 
   describe 'getNetworkInterfaces', () ->
     it 'should return a NetworkInterface', (done) ->
-      cam.getNetworkInterfaces (err, data) ->
+      cam.getNetworkInterfaces (err, networkInterfaces) ->
         assert.equal err, null
-        assert.equal data.networkInterfaces.$.token, 'eth0' # Defined in serverMockup/device.GetNetworkInterfaces.xml
+        assert.equal networkInterfaces[0].$.token, 'eth0' # Defined in serverMockup/device.GetNetworkInterfaces.xml
         done()
   describe 'setNetworkInterfaces', () ->
     it 'should set manual IPv4, update the Cam object with the new IP and return RebootNeeded', (done) ->


### PR DESCRIPTION
Hi @agsh  and @chriswiggins 
I've got some new ONVIF Cameras that use Profile T and H265.
I've added support and just wanted you to have a quick check before I merge to master.

The two important changes in ONVIF are
  You must use GetServices() to get the XAddrs and not GetCapabilities. This lets us check if the Media XAddr is 'media10' or 'media20'  (Media Version 1.0 or Media Version 2.0).

  The for GetProfiles() I have to use the old Media XML format and XML namespace or the new Media2 XML format and namespace. This lets me get a list of Profiles where the Encoder can be H265.
  The reply for Media2 GetProfiles() is in a slightly different format (different XML tag names) but I modify the result so the reults are in the same format as the old media10 GetProfiles. This means the 'activeProfile' and uses of cam_obj.Profiles do not need to make any changes to support Profile T and H265.

I have not made a change to Mock Server yet to reply with Media2. But I've tested it on two HikVision cameras in the office and will test with some new Bosch cameras with H265 on a customer site next week.


