### PR TITLE
setting the port for pull messages to user-provided ports

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -1027,7 +1027,7 @@ Cam.prototype._parseUrl = function(address) {
 	const parsedAddress = url.parse(address);
 	// If host for service and default host differs, also if preserve address property set
 	// we substitute host, hostname and port from settings then rebuild the href using .format
-	if (this.preserveAddress && this.hostname !== parsedAddress.hostname) {
+	if (this.preserveAddress && (this.hostname !== parsedAddress.hostname || this.port !== parsedAddress.port)) {
 		parsedAddress.hostname = this.hostname;
 		parsedAddress.host = this.hostname + ':' + this.port;
 		parsedAddress.port = this.port;

--- a/lib/events.js
+++ b/lib/events.js
@@ -223,10 +223,6 @@ module.exports = function(Cam) {
 		let subscriptionId = null;
 		try {
 			urlAddress = this.events.subscription.subscriptionReference.address;
-			// this is in case requests to the camera are getting port forwarded, in which case
-			// the camera will return what it thinks is the correct port (eg: 80 instead of 554),
-			// causing the listener to not receive any events
-			urlAddress.port = this.port || urlAddress.port;
 		} catch (e) {
 			throw new Error('You should create pull-point subscription first!');
 		}

--- a/lib/events.js
+++ b/lib/events.js
@@ -223,6 +223,10 @@ module.exports = function(Cam) {
 		let subscriptionId = null;
 		try {
 			urlAddress = this.events.subscription.subscriptionReference.address;
+			// this is in case requests to the camera are getting port forwarded, in which case
+			// the camera will return what it thinks is the correct port (eg: 80 instead of 554),
+			// causing the listener to not receive any events
+			urlAddress.port = this.port || urlAddress.port;
 		} catch (e) {
 			throw new Error('You should create pull-point subscription first!');
 		}


### PR DESCRIPTION
Hi, first of all, thank you so much for this project, it has really saved me quite a bit of time, anyways first time contributing to an open source project, so if anything should be improved please let me know.

I found an issue when the camera receives requests via port forwarding, eg: requests to `external_ip:554`, get forwarded to the camera on the actual Onvif port 80, this will cause the camera to respond with port 80 for the address that is used for establishing a subscription, which in turn means no events will be received, below is a trivial workaround that from my experience works.

I wasn't sure how I could add a test case for this, so any pointers would be appreciated.
