### PR TITLE
Add action string to Content-Type in ONVIF HTTP Request Header, fixes for PTZSpaces and RelativePTZ

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -366,7 +366,7 @@ Cam.prototype.getSystemDateAndTime = function(callback) {
 			// One HikVision camera returned a 401 error code and the following HTML...
 			//   <!DOCTYPE html><html><head><title>Document Error: Unauthorized</title></head><body><h2>Access Error: 401 -- Unauthorized</h2>
 			//   <p>Authentication Error: Access Denied! Authorization required.</p></body></html>
-			if ((xml && (xml.toLowerCase().includes('sender not authorized')) || (xml.toLowerCase().includes('unauthorized'))) ||
+			if ((xml && (xml.toLowerCase().includes('sender not authorized') || xml.toLowerCase().includes('unauthorized'))) ||
                 (statusCode && statusCode == 401)
 			) {
 				// Try again with a Username and Password

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -5,18 +5,17 @@
  * @licence MIT
  */
 
-const http = require('http')
-	, https = require('https')
-	, crypto = require('crypto')
-	, events = require('events')
-	, url = require('url')
-	, util = require('util')
-	, linerase = require('./utils').linerase
-	, parseSOAPString = require('./utils').parseSOAPString
-	, parseString = require('xml2js').parseString
-	, stripPrefix = require('xml2js').processors.stripPrefix
-	, emptyFn = function() {}
-;
+const http = require('http'),
+	https = require('https'),
+	crypto = require('crypto'),
+	events = require('events'),
+	url = require('url'),
+	util = require('util'),
+	linerase = require('./utils').linerase,
+	parseSOAPString = require('./utils').parseSOAPString,
+	parseString = require('xml2js').parseString,
+	stripPrefix = require('xml2js').processors.stripPrefix,
+	emptyFn = function() {};
 
 /**
  * @callback Cam~MessageCallback
@@ -88,15 +87,15 @@ var Cam = function(options, callback) {
 	this.timeout = options.timeout || 120000;
 	this.agent = options.agent || false;
 	/**
-	 * Force using hostname and port from constructor for the services
-	 * @type {boolean}
-	 */
+     * Force using hostname and port from constructor for the services
+     * @type {boolean}
+     */
 	this.preserveAddress = options.preserveAddress || false;
 
 	this.events = {};
 	/**
-	 * Bind event handling to the `event` event
-	 */
+     * Bind event handling to the `event` event
+     */
 	this.on('newListener', function(name) {
 		// if this is the first listener, start pulling subscription
 		if (name === 'event' && this.listeners(name).length === 0) {
@@ -130,7 +129,7 @@ Cam.prototype.connect = function(callback) {
 		if (err) {
 			return callback.call(this, err, null, xml);
 		}
-		this.getServices(true,function(err) {
+		this.getServices(true, function(err) {
 			if (err) {
 				return this.getCapabilities(function(err, data, xml) {
 					if (err) {
@@ -141,6 +140,7 @@ Cam.prototype.connect = function(callback) {
 			}
 			return callUpstartFunctions.call(this);
 		}.bind(this));
+
 		function callUpstartFunctions() {
 			var upstartFunctions = [];
 
@@ -165,9 +165,9 @@ Cam.prototype.connect = function(callback) {
 							if (!--count) {
 								this.getActiveSources();
 								/**
-								 * Indicates that device is connected.
-								 * @event Cam#connect
-								 */
+                                 * Indicates that device is connected.
+                                 * @event Cam#connect
+                                 */
 								this.emit('connect');
 								if (callback) {
 									return callback.call(this, err);
@@ -211,7 +211,7 @@ Cam.prototype._request = function(options, callback) {
 	// xml2js returns a callback, so call _requestPart2 from the callback
 	if (options.action == undefined || options.action == null) {
 		let xml2jsOptions = {
-			'xmlns': true,                   // Creates the $ns object that contains the full namepace and local name of each XML Tag
+			'xmlns': true, // Creates the $ns object that contains the full namepace and local name of each XML Tag
 			tagNameProcessors: [stripPrefix] // Removes the namespace from each tag so we can parse Key:Value pairs of Tags
 		};
 		parseString(options.body, xml2jsOptions, (err, result) => {
@@ -236,25 +236,28 @@ Cam.prototype._requestPart2 = function(options, callback) {
 	var _this = this;
 	var callbackExecuted = false;
 	var reqOptions = options.url || {
-		hostname: this.hostname
-		, port: this.port
-		, agent: this.agent //Supports things like https://www.npmjs.com/package/proxy-agent which provide SOCKS5 and other connections
-		, path: options.service
-			? (this.uri[options.service] ? this.uri[options.service].path : options.service)
-			: this.path
-		, timeout: this.timeout
+		hostname: this.hostname,
+		port: this.port,
+		agent: this.agent //Supports things like https://www.npmjs.com/package/proxy-agent which provide SOCKS5 and other connections
+		,
+		path: options.service ?
+			(this.uri[options.service] ? this.uri[options.service].path : options.service) : this.path,
+		timeout: this.timeout
 	};
 	reqOptions.headers = {
-		'Content-Type': `application/soap+xml; charset: utf-8; action="${options.action}"`
-		, 'Content-Length': Buffer.byteLength(options.body, 'utf8')//options.body.length chinese will be wrong here
-		, charset: 'utf-8'
+		'Content-Type': `application/soap+xml; charset: utf-8; action="${options.action}"`,
+		'Content-Length': Buffer.byteLength(options.body, 'utf8') //options.body.length chinese will be wrong here
+		,
+		charset: 'utf-8'
 	};
 
 	reqOptions.method = 'POST';
 	var httpLib = this.useSecure ? https : http;
 	reqOptions = this.useSecure ? Object.assign({}, this.secureOpts, reqOptions) : reqOptions;
 	var req = httpLib.request(reqOptions, function(res) {
-		var bufs = [], length = 0;
+		const statusCode = res.statusCode;
+		var bufs = [],
+			length = 0;
 		res.on('data', function(chunk) {
 			bufs.push(chunk);
 			length += chunk.length;
@@ -266,12 +269,13 @@ Cam.prototype._requestPart2 = function(options, callback) {
 			callbackExecuted = true;
 			var xml = Buffer.concat(bufs, length).toString('utf8');
 			/**
-			 * Indicates raw xml response from device.
-			 * @event Cam#rawResponse
-			 * @type {string}
-			 */
-			_this.emit('rawResponse', xml);
-			parseSOAPString(xml, callback);
+             * Indicates raw xml response from device.
+             * @event Cam#rawResponse
+             * @type {string} xml received from device
+             * @type {number} HTTP statusCode received from device
+             */
+			_this.emit('rawResponse', xml, statusCode);
+			parseSOAPString(xml, callback, statusCode); // xml and statusCode are passed in. Callback is the function called after the XML is parsed
 		});
 	});
 
@@ -301,10 +305,10 @@ Cam.prototype._requestPart2 = function(options, callback) {
 		}
 	});
 	/**
-	 * Indicates raw xml request to device.
-	 * @event Cam#rawRequest
-	 * @type {Object}
-	 */
+     * Indicates raw xml request to device.
+     * @event Cam#rawRequest
+     * @type {Object}
+     */
 	this.emit('rawRequest', options.body);
 	req.write(options.body);
 	req.end();
@@ -331,13 +335,12 @@ Cam.prototype.getSystemDateAndTime = function(callback) {
 	// if the camera implements Replay Attack Protection (eg Axis)
 	this._request({
 		// Try the Unauthenticated Request first. Do not use this._envelopeHeader() as we don't have timeShift yet.
-		body:
-			'<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">' +
-			'<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">' +
-			'<GetSystemDateAndTime xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
-			'</s:Body>' +
-			'</s:Envelope>'
-	}, function(err, data, xml) {
+		body: '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">' +
+            '<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">' +
+            '<GetSystemDateAndTime xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
+            '</s:Body>' +
+            '</s:Envelope>'
+	}, function(err, data, xml, statusCode) {
 		if (!err) {
 			try {
 				let systemDateAndTime = data[0]['getSystemDateAndTimeResponse'][0]['systemDateAndTime'][0];
@@ -359,12 +362,18 @@ Cam.prototype.getSystemDateAndTime = function(callback) {
 			}
 		}
 		if (err) {
-			if (xml && xml.toLowerCase().includes('sender not authorized')) {
+			// some cameras return XML with 'sender not authorized'
+			// One HikVision camera returned a 401 error code and the following HTML...
+			//   <!DOCTYPE html><html><head><title>Document Error: Unauthorized</title></head><body><h2>Access Error: 401 -- Unauthorized</h2>
+			//   <p>Authentication Error: Access Denied! Authorization required.</p></body></html>
+			if ((xml && (xml.toLowerCase().includes('sender not authorized')) || (xml.toLowerCase().includes('unauthorized'))) ||
+                (statusCode && statusCode == 401)
+			) {
 				// Try again with a Username and Password
 				this._request({
 					body: this._envelopeHeader() +
-					'<GetSystemDateAndTime xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
-					this._envelopeFooter()
+                        '<GetSystemDateAndTime xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
+                        this._envelopeFooter()
 				}, function(err, data, xml) {
 					try {
 						let systemDateAndTime = data[0]['getSystemDateAndTimeResponse'][0]['systemDateAndTime'][0];
@@ -421,40 +430,40 @@ Cam.prototype.setSystemDateAndTime = function(options, callback) {
 	}
 	this._request({
 		body: this._envelopeHeader() +
-			'<SetSystemDateAndTime xmlns="http://www.onvif.org/ver10/device/wsdl">' +
-			'<DateTimeType>' +
-			options.dateTimeType +
-			'</DateTimeType>' +
-			'<DaylightSavings>' +
-			( !!options.daylightSavings ) +
-			'</DaylightSavings>' +
-			( options.timezone !== undefined ?
-				'<TimeZone>' +
-				'<TZ xmlns="http://www.onvif.org/ver10/schema">' +
-				options.timezone +
-				'</TZ>' +
-				'</TimeZone>' : '' ) +
-			// ( options.dateTime !== undefined && options.dateTime.getDate instanceof Date ?
-			( options.dateTime !== undefined && options.dateTime instanceof Date ?
-				'<UTCDateTime>' +
-				'<Time xmlns="http://www.onvif.org/ver10/schema">' +
-				'<Hour>' + options.dateTime.getUTCHours() + '</Hour>' +
-				'<Minute>' + options.dateTime.getUTCMinutes() + '</Minute>' +
-				'<Second>' + options.dateTime.getUTCSeconds() + '</Second>' +
-				'</Time>' +
-				'<Date xmlns="http://www.onvif.org/ver10/schema">' +
-				'<Year>' + options.dateTime.getUTCFullYear() + '</Year>' +
-				'<Month>' + (options.dateTime.getUTCMonth() + 1) + '</Month>' +
-				'<Day>' + options.dateTime.getUTCDate() + '</Day>' +
-				'</Date>' +
-				'</UTCDateTime>' : '' ) +
-			'</SetSystemDateAndTime>' +
-			this._envelopeFooter()
+            '<SetSystemDateAndTime xmlns="http://www.onvif.org/ver10/device/wsdl">' +
+            '<DateTimeType>' +
+            options.dateTimeType +
+            '</DateTimeType>' +
+            '<DaylightSavings>' +
+            (!!options.daylightSavings) +
+            '</DaylightSavings>' +
+            (options.timezone !== undefined ?
+            	'<TimeZone>' +
+                '<TZ xmlns="http://www.onvif.org/ver10/schema">' +
+                options.timezone +
+                '</TZ>' +
+                '</TimeZone>' : '') +
+            // ( options.dateTime !== undefined && options.dateTime.getDate instanceof Date ?
+            (options.dateTime !== undefined && options.dateTime instanceof Date ?
+            	'<UTCDateTime>' +
+                '<Time xmlns="http://www.onvif.org/ver10/schema">' +
+                '<Hour>' + options.dateTime.getUTCHours() + '</Hour>' +
+                '<Minute>' + options.dateTime.getUTCMinutes() + '</Minute>' +
+                '<Second>' + options.dateTime.getUTCSeconds() + '</Second>' +
+                '</Time>' +
+                '<Date xmlns="http://www.onvif.org/ver10/schema">' +
+                '<Year>' + options.dateTime.getUTCFullYear() + '</Year>' +
+                '<Month>' + (options.dateTime.getUTCMonth() + 1) + '</Month>' +
+                '<Day>' + options.dateTime.getUTCDate() + '</Day>' +
+                '</Date>' +
+                '</UTCDateTime>' : '') +
+            '</SetSystemDateAndTime>' +
+            this._envelopeFooter()
 	}, function(err, data, xml) {
 		if (err || linerase(data).setSystemDateAndTimeResponse !== '') {
-			return callback.call(this, linerase(data).setSystemDateAndTimeResponse !== ''
-				? new Error('Wrong `SetSystemDateAndTime` response')
-				: err, data, xml);
+			return callback.call(this, linerase(data).setSystemDateAndTimeResponse !== '' ?
+				new Error('Wrong `SetSystemDateAndTime` response') :
+				err, data, xml);
 		}
 		//get new system time from device
 		this.getSystemDateAndTime(callback);
@@ -539,29 +548,29 @@ Cam.prototype.setSystemDateAndTime = function(options, callback) {
 Cam.prototype.getCapabilities = function(callback) {
 	this._request({
 		body: this._envelopeHeader() +
-			'<GetCapabilities xmlns="http://www.onvif.org/ver10/device/wsdl">' +
-			'<Category>All</Category>' +
-			'</GetCapabilities>' +
-			this._envelopeFooter()
+            '<GetCapabilities xmlns="http://www.onvif.org/ver10/device/wsdl">' +
+            '<Category>All</Category>' +
+            '</GetCapabilities>' +
+            this._envelopeFooter()
 	}, function(err, data, xml) {
 		if (!err) {
 			/**
-			 * Device capabilities
-			 * @name Cam#capabilities
-			 * @type {Cam~Capabilities}
-			 */
+             * Device capabilities
+             * @name Cam#capabilities
+             * @type {Cam~Capabilities}
+             */
 			this.capabilities = linerase(data[0]['getCapabilitiesResponse'][0]['capabilities'][0]);
 			// fill Cam#uri property
 			if (!this.uri) {
 				/**
-				 * Device service URIs
-				 * @name Cam#uri
-				 * @property {url} [PTZ]
-				 * @property {url} [media]
-				 * @property {url} [imaging]
-				 * @property {url} [events]
-				 * @property {url} [device]
-				 */
+                 * Device service URIs
+                 * @name Cam#uri
+                 * @property {url} [PTZ]
+                 * @property {url} [media]
+                 * @property {url} [imaging]
+                 * @property {url} [events]
+                 * @property {url} [device]
+                 */
 				this.uri = {};
 			}
 			['PTZ', 'media', 'imaging', 'events', 'device'].forEach(function(name) {
@@ -580,7 +589,7 @@ Cam.prototype.getCapabilities = function(callback) {
 			}
 			// HACK for a Profile G NVR that has 'replay' but did not have 'recording' in GetCapabilities
 			if ((this.uri['replay']) && !this.uri['recording']) {
-				var tempRecorderXaddr = this.uri['replay'].href.replace('replay','recording');
+				var tempRecorderXaddr = this.uri['replay'].href.replace('replay', 'recording');
 				console.warn("WARNING: Adding " + tempRecorderXaddr + " for bad Profile G device");
 				this.uri['recording'] = url.parse(tempRecorderXaddr);
 			}
@@ -598,15 +607,15 @@ Cam.prototype.getCapabilities = function(callback) {
 Cam.prototype.getServiceCapabilities = function(callback) {
 	this._request({
 		body: this._envelopeHeader() +
-			'<GetServiceCapabilities xmlns="http://www.onvif.org/ver10/device/wsdl" />' +
-			this._envelopeFooter()
+            '<GetServiceCapabilities xmlns="http://www.onvif.org/ver10/device/wsdl" />' +
+            this._envelopeFooter()
 	}, function(err, data, xml) {
 		if (!err) {
 			data = linerase(data);
 			this.serviceCapabilities = {
-				network: data.getServiceCapabilitiesResponse.capabilities.network.$
-				, security: data.getServiceCapabilitiesResponse.capabilities.security.$
-				, system: data.getServiceCapabilitiesResponse.capabilities.system.$
+				network: data.getServiceCapabilitiesResponse.capabilities.network.$,
+				security: data.getServiceCapabilitiesResponse.capabilities.security.$,
+				system: data.getServiceCapabilitiesResponse.capabilities.system.$
 			};
 			if (data.getServiceCapabilitiesResponse.capabilities.misc) {
 				this.serviceCapabilities.auxiliaryCommands = data.getServiceCapabilitiesResponse.capabilities.misc.$.AuxiliaryCommands.split(' ');
@@ -642,25 +651,25 @@ Cam.prototype.getActiveSources = function() {
 	//The following code block supports a camera with a single video source
 	//as well as encoders with multiple sources. By default, the first source is set to the activeSource.
 	/**
-	 * Default profiles for the device
-	 * @name Cam#defaultProfiles
-	 * @type {Array.<Cam~Profile>}
-	 */
+     * Default profiles for the device
+     * @name Cam#defaultProfiles
+     * @type {Array.<Cam~Profile>}
+     */
 	this.defaultProfiles = [];
 	/**
-	 * Active video sources
-	 * @name Cam#activeSources
-	 * @type {Array.<Cam~ActiveSource>}
-	 */
+     * Active video sources
+     * @name Cam#activeSources
+     * @type {Array.<Cam~ActiveSource>}
+     */
 	this.activeSources = [];
 
 	this.videoSources.forEach(function(videoSource, idx) {
 		// let's choose first appropriate profile for our video source and make it default
-		var videoSrcToken = videoSource.$.token
-			, appropriateProfiles = this.profiles.filter(function(profile) {
-				return (profile.videoSourceConfiguration
-					? profile.videoSourceConfiguration.sourceToken === videoSrcToken
-					: false) && (profile.videoEncoderConfiguration);
+		var videoSrcToken = videoSource.$.token,
+			appropriateProfiles = this.profiles.filter(function(profile) {
+				return (profile.videoSourceConfiguration ?
+					profile.videoSourceConfiguration.sourceToken === videoSrcToken :
+					false) && (profile.videoEncoderConfiguration);
 			});
 		if (appropriateProfiles.length === 0) {
 			if (idx === 0) {
@@ -672,19 +681,19 @@ Cam.prototype.getActiveSources = function() {
 
 		if (idx === 0) {
 			/**
-			 * Default selected profile for the device
-			 * @name Cam#defaultProfile
-			 * @type {Cam~Profile}
-			 */
+             * Default selected profile for the device
+             * @name Cam#defaultProfile
+             * @type {Cam~Profile}
+             */
 			this.defaultProfile = appropriateProfiles[0];
 		}
 
 		this.defaultProfiles[idx] = appropriateProfiles[0];
 
 		this.activeSources[idx] = {
-			sourceToken: videoSource.$.token
-			, profileToken: this.defaultProfiles[idx].$.token
-			, videoSourceConfigurationToken: this.defaultProfiles[idx].videoSourceConfiguration.$.token
+			sourceToken: videoSource.$.token,
+			profileToken: this.defaultProfiles[idx].$.token,
+			videoSourceConfigurationToken: this.defaultProfiles[idx].videoSourceConfiguration.$.token
 		};
 		if (this.defaultProfiles[idx].videoEncoderConfiguration) {
 			var configuration = this.defaultProfiles[idx].videoEncoderConfiguration;
@@ -697,33 +706,33 @@ Cam.prototype.getActiveSources = function() {
 
 		if (idx === 0) {
 			/**
-			 * Current active video source
-			 * @name Cam#activeSource
-			 * @type {Cam~ActiveSource}
-			 */
+             * Current active video source
+             * @name Cam#activeSource
+             * @type {Cam~ActiveSource}
+             */
 			this.activeSource = this.activeSources[idx];
 		}
 
 		if (this.defaultProfiles[idx].PTZConfiguration) {
 			this.activeSources[idx].ptz = {
-				name: this.defaultProfiles[idx].PTZConfiguration.name
-				, token: this.defaultProfiles[idx].PTZConfiguration.$.token
+				name: this.defaultProfiles[idx].PTZConfiguration.name,
+				token: this.defaultProfiles[idx].PTZConfiguration.$.token
 			};
 			/*
-			TODO Think about it
-			if (idx === 0) {
-				this.defaultProfile.PTZConfiguration = this.activeSources[idx].PTZConfiguration;
-			}*/
+            TODO Think about it
+            if (idx === 0) {
+            	this.defaultProfile.PTZConfiguration = this.activeSources[idx].PTZConfiguration;
+            }*/
 		}
 	}.bind(this));
 
 	// If we haven't got any active source, send a warning
 	if (this.activeSources.length === 0) {
 		/**
-		 * Indicates any warning.
-		 * @event Cam#rawResponse
-		 * @type {string}
-		 */
+         * Indicates any warning.
+         * @event Cam#warning
+         * @type {string}
+         */
 		this.emit('warning', 'There are no active sources at this device');
 	}
 };
@@ -755,17 +764,17 @@ Cam.prototype.getServices = function(includeCapability, callback) {
 	}
 	this._request({
 		body: this._envelopeHeader() +
-		'<GetServices xmlns="http://www.onvif.org/ver10/device/wsdl">' +
-			'<IncludeCapability>' + includeCapability + '</IncludeCapability>' +
-		'</GetServices>' +
-		this._envelopeFooter(),
+            '<GetServices xmlns="http://www.onvif.org/ver10/device/wsdl">' +
+            '<IncludeCapability>' + includeCapability + '</IncludeCapability>' +
+            '</GetServices>' +
+            this._envelopeFooter(),
 	}, function(err, data, xml) {
 		if (!err) {
 			/**
-			 * Device services
-			 * @name Cam#services
-			 * @type {Cam~Services}
-			 */
+             * Device services
+             * @name Cam#services
+             * @type {Cam~Services}
+             */
 			this.services = linerase(data).getServicesResponse.service;
 
 			// ONVIF Profile T introduced Media2 (ver20) so cameras from around 2020/2021 will have
@@ -774,21 +783,21 @@ Cam.prototype.getServices = function(includeCapability, callback) {
 			// fill Cam#uri property
 			if (!this.uri) {
 				/**
-				 * Device service URIs
-				 * @name Cam#uri
-				 * @property {url} [PTZ]
-				 * @property {url} [media]
-				 * @property {url} [media2]
-				 * @property {url} [imaging]
-				 * @property {url} [events]
-				 * @property {url} [device]
-				 */
+                 * Device service URIs
+                 * @name Cam#uri
+                 * @property {url} [PTZ]
+                 * @property {url} [media]
+                 * @property {url} [media2]
+                 * @property {url} [imaging]
+                 * @property {url} [events]
+                 * @property {url} [device]
+                 */
 				this.uri = {};
 			}
 			this.media2Support = false;
 			this.services.forEach((service) => {
 				// Look for services with namespaces and XAddr values
-				if (Object.prototype.hasOwnProperty.call(service,'namespace') && Object.prototype.hasOwnProperty.call(service,'XAddr')) {
+				if (Object.prototype.hasOwnProperty.call(service, 'namespace') && Object.prototype.hasOwnProperty.call(service, 'XAddr')) {
 					// Only parse ONVIF namespaces. Axis cameras return Axis namespaces in GetServices
 					let parsedNamespace = url.parse(service.namespace);
 					if (parsedNamespace.hostname === 'www.onvif.org') {
@@ -832,8 +841,8 @@ Cam.prototype.getServices = function(includeCapability, callback) {
 Cam.prototype.getDeviceInformation = function(callback) {
 	this._request({
 		body: this._envelopeHeader() +
-			'<GetDeviceInformation xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
-			this._envelopeFooter()
+            '<GetDeviceInformation xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
+            this._envelopeFooter()
 	}, function(err, data, xml) {
 		if (!err) {
 			this.deviceInformation = linerase(data).getDeviceInformationResponse;
@@ -864,8 +873,8 @@ Cam.prototype.getDeviceInformation = function(callback) {
 Cam.prototype.getHostname = function(callback) {
 	this._request({
 		body: this._envelopeHeader() +
-			'<GetHostname xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
-			this._envelopeFooter()
+            '<GetHostname xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
+            this._envelopeFooter()
 	}, function(err, data, xml) {
 		if (callback) {
 			callback.call(this, err, err ? null : linerase(data).getHostnameResponse.hostnameInformation, xml);
@@ -893,14 +902,14 @@ Cam.prototype.getHostname = function(callback) {
 Cam.prototype.getScopes = function(callback) {
 	this._request({
 		body: this._envelopeHeader() +
-			'<GetScopes xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
-			this._envelopeFooter()
+            '<GetScopes xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
+            this._envelopeFooter()
 	}, function(err, data, xml) {
 		if (!err) {
 			/**
-			 * Device scopes
-			 * @type {undefined|Array<Cam~Scope>}
-			 */
+             * Device scopes
+             * @type {undefined|Array<Cam~Scope>}
+             */
 			this.scopes = linerase(data).getScopesResponse.scopes;
 			if (this.scopes === undefined) {
 				this.scopes = [];
@@ -922,10 +931,10 @@ Cam.prototype.getScopes = function(callback) {
 Cam.prototype.setScopes = function(scopes, callback) {
 	this._request({
 		body: this._envelopeHeader() +
-			'<SetScopes xmlns="http://www.onvif.org/ver10/device/wsdl">' +
-			scopes.map(function(uri) { return '<Scopes>' + uri + '</Scopes>'; }).join('') +
-			'</SetScopes>' +
-			this._envelopeFooter()
+            '<SetScopes xmlns="http://www.onvif.org/ver10/device/wsdl">' +
+            scopes.map(function(uri) { return '<Scopes>' + uri + '</Scopes>'; }).join('') +
+            '</SetScopes>' +
+            this._envelopeFooter()
 	}, function(err, data, xml) {
 		if (err || linerase(data).setScopesResponse !== '') {
 			return callback(linerase(data).setScopesResponse !== '' ? new Error('Wrong `SetScopes` response') : err, data, xml);
@@ -941,10 +950,10 @@ Cam.prototype.setScopes = function(scopes, callback) {
  */
 Cam.prototype.systemReboot = function(callback) {
 	this._request({
-		service: 'deviceIO'
-		, body: this._envelopeHeader() +
-			'<SystemReboot xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
-			this._envelopeFooter()
+		service: 'deviceIO',
+		body: this._envelopeHeader() +
+            '<SystemReboot xmlns="http://www.onvif.org/ver10/device/wsdl"/>' +
+            this._envelopeFooter()
 	}, function(err, res, xml) {
 		if (!err) {
 			res = res[0].systemRebootResponse[0].message[0];
@@ -965,16 +974,16 @@ Cam.prototype.systemReboot = function(callback) {
  * @param {boolean} [hard=false] Reset network settings
  * @param {Cam~SetSystemFactoryDefaultCallback} callback
  */
-Cam.prototype.setSystemFactoryDefault = function(hard,callback) {
+Cam.prototype.setSystemFactoryDefault = function(hard, callback) {
 	if (callback === undefined) {
 		callback = hard;
 		hard = false;
 	}
 	let body = this._envelopeHeader() +
-		'<SetSystemFactoryDefault xmlns="http://www.onvif.org/ver10/device/wsdl">' +
-			'<FactoryDefault>' + (hard ? 'Hard' : 'Soft') + '</FactoryDefault>' +
-		'</SetSystemFactoryDefault>' +
-		this._envelopeFooter();
+        '<SetSystemFactoryDefault xmlns="http://www.onvif.org/ver10/device/wsdl">' +
+        '<FactoryDefault>' + (hard ? 'Hard' : 'Soft') + '</FactoryDefault>' +
+        '</SetSystemFactoryDefault>' +
+        this._envelopeFooter();
 	this._request({
 		service: 'device',
 		body: body,
@@ -1001,9 +1010,9 @@ Cam.prototype._passwordDigest = function() {
 	cryptoDigest.update(Buffer.concat([nonce, Buffer.from(timestamp, 'ascii'), Buffer.from(this.password, 'ascii')]));
 	let passdigest = cryptoDigest.digest('base64');
 	return {
-		passdigest: passdigest
-		, nonce: nonce.toString('base64')
-		, timestamp: timestamp
+		passdigest: passdigest,
+		nonce: nonce.toString('base64'),
+		timestamp: timestamp
 	};
 };
 
@@ -1015,22 +1024,22 @@ Cam.prototype._passwordDigest = function() {
  */
 Cam.prototype._envelopeHeader = function(openHeader) {
 	var header = '<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing">' +
-		'<s:Header>';
+        '<s:Header>';
 	// Only insert Security if there is a username and password
 	if (this.username && this.password) {
 		var req = this._passwordDigest();
 		header += '<Security s:mustUnderstand="1" xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd">' +
-			'<UsernameToken>' +
-			'<Username>' + this.username + '</Username>' +
-			'<Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">' + req.passdigest + '</Password>' +
-			'<Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">' + req.nonce + '</Nonce>' +
-			'<Created xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">' + req.timestamp + '</Created>' +
-			'</UsernameToken>' +
-			'</Security>';
+            '<UsernameToken>' +
+            '<Username>' + this.username + '</Username>' +
+            '<Password Type="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest">' + req.passdigest + '</Password>' +
+            '<Nonce EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary">' + req.nonce + '</Nonce>' +
+            '<Created xmlns="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">' + req.timestamp + '</Created>' +
+            '</UsernameToken>' +
+            '</Security>';
 	}
 	if (!(openHeader !== undefined && openHeader)) {
 		header += '</s:Header>' +
-			'<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">';
+            '<s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">';
 	}
 	return header;
 };
@@ -1042,7 +1051,7 @@ Cam.prototype._envelopeHeader = function(openHeader) {
  */
 Cam.prototype._envelopeFooter = function() {
 	return '</s:Body>' +
-		'</s:Envelope>';
+        '</s:Envelope>';
 };
 
 /**
@@ -1069,7 +1078,7 @@ module.exports = {
 };
 
 // extending Camera prototype
-require('./device' )(Cam);
+require('./device')(Cam);
 require('./events')(Cam);
 require('./media')(Cam);
 require('./ptz')(Cam);

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -215,20 +215,24 @@ Cam.prototype._request = function(options, callback) {
 		let xml2jsOptions = {
 			'xmlns': true,                   // Creates the $ns object that contains the full namepace and local name of each XML Tag
 			tagNameProcessors: [stripPrefix] // Removes the namespace from each tag so we can parse Key:Value pairs of Tags
-		}
+		};
 		parseString(options.body, xml2jsOptions, function(err, result) {
 			// if (err) console.log(err);
 			// console.log(result);
 
-			// look for Key:Value pairs that do not start with $ or $ns
-			for (const [key, value] of Object.entries(result['Envelope']['Body'][0])) {
-				if (key.startsWith('$') == false)
-					options.action = value[0]['$ns'].uri + '/' + value[0]['$ns'].local
+			// look for first Key:Value pairs that do not start with $ or $ns
+			// for (const [key, value] of Object.entries(result['Envelope']['Body'][0])) {  // Node 7 or higher
+			for (const key of Object.keys(result['Envelope']['Body'][0])) {
+				const value = result['Envelope']['Body'][0][key];
+				if (key.startsWith('$') == false) {
+					options.action = value[0]['$ns'].uri + '/' + value[0]['$ns'].local;
+					break;
+				}
 			}
-			_this._requestPart2.call(_this, options, callback)
-		})
+			_this._requestPart2.call(_this, options, callback);
+		});
 	} else {
-		_this._requestPart2.call(_this, options, callback)
+		_this._requestPart2.call(_this, options, callback);
 	}
 };
 

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -13,6 +13,8 @@ const http = require('http')
 	, util = require('util')
 	, linerase = require('./utils').linerase
 	, parseSOAPString = require('./utils').parseSOAPString
+	, parseString = require('xml2js').parseString
+	, stripPrefix = require('xml2js').processors.stripPrefix
 	, emptyFn = function() {}
 ;
 
@@ -196,15 +198,42 @@ Cam.prototype.connect = function(callback) {
  * @param {object} options
  * @param {string} [options.service] Name of service (ptz, media, etc)
  * @param {string} options.body SOAP body
- * @param {string} [options.url] Defines another url to request
- * @param {boolean} [options.ptz] make request to PTZ uri or not
+ * @param {string} [options.url] Defines another url to request instead of using the URLs from GetCapabilities/GetServices
  * @param {Cam~RequestCallback} callback response callback
  * @private
  */
 Cam.prototype._request = function(options, callback) {
+	const _this = this;
+
 	if (typeof callback !== 'function') {
 		throw new Error('`callback` must be a function');
 	}
+
+	// Generate the HTTP Content-Type 'action' string by parsing our outgoing ONVIF XML message with xml2js
+	// xml2js returns a callback, so call _requestPart2 from the callback
+	if (options.action == undefined || options.action == null) {
+		let xml2jsOptions = {
+			'xmlns': true,                   // Creates the $ns object that contains the full namepace and local name of each XML Tag
+			tagNameProcessors: [stripPrefix] // Removes the namespace from each tag so we can parse Key:Value pairs of Tags
+		}
+		parseString(options.body, xml2jsOptions, function(err, result) {
+			// if (err) console.log(err);
+			// console.log(result);
+
+			// look for Key:Value pairs that do not start with $ or $ns
+			for (const [key, value] of Object.entries(result['Envelope']['Body'][0])) {
+				if (key.startsWith('$') == false)
+					options.action = value[0]['$ns'].uri + '/' + value[0]['$ns'].local
+			}
+			_this._requestPart2.call(_this, options, callback)
+		})
+	} else {
+		_this._requestPart2.call(_this, options, callback)
+	}
+};
+
+Cam.prototype._requestPart2 = function(options, callback) {
+
 	var _this = this;
 	var callbackExecuted = false;
 	var reqOptions = options.url || {
@@ -217,7 +246,7 @@ Cam.prototype._request = function(options, callback) {
 		, timeout: this.timeout
 	};
 	reqOptions.headers = {
-		'Content-Type': 'application/soap+xml'
+		'Content-Type': `application/soap+xml; charset: utf-8; action="${options.action}"`
 		, 'Content-Length': Buffer.byteLength(options.body, 'utf8')//options.body.length chinese will be wrong here
 		, charset: 'utf-8'
 	};

--- a/lib/cam.js
+++ b/lib/cam.js
@@ -203,8 +203,6 @@ Cam.prototype.connect = function(callback) {
  * @private
  */
 Cam.prototype._request = function(options, callback) {
-	const _this = this;
-
 	if (typeof callback !== 'function') {
 		throw new Error('`callback` must be a function');
 	}
@@ -216,23 +214,20 @@ Cam.prototype._request = function(options, callback) {
 			'xmlns': true,                   // Creates the $ns object that contains the full namepace and local name of each XML Tag
 			tagNameProcessors: [stripPrefix] // Removes the namespace from each tag so we can parse Key:Value pairs of Tags
 		};
-		parseString(options.body, xml2jsOptions, function(err, result) {
-			// if (err) console.log(err);
-			// console.log(result);
-
+		parseString(options.body, xml2jsOptions, (err, result) => {
 			// look for first Key:Value pairs that do not start with $ or $ns
 			// for (const [key, value] of Object.entries(result['Envelope']['Body'][0])) {  // Node 7 or higher
-			for (const key of Object.keys(result['Envelope']['Body'][0])) {
-				const value = result['Envelope']['Body'][0][key];
+			for (const key of Object.keys(result.Envelope.Body[0])) {
+				const value = result.Envelope.Body[0][key];
 				if (key.startsWith('$') == false) {
 					options.action = value[0]['$ns'].uri + '/' + value[0]['$ns'].local;
 					break;
 				}
 			}
-			_this._requestPart2.call(_this, options, callback);
+			this._requestPart2.call(this, options, callback);
 		});
 	} else {
-		_this._requestPart2.call(_this, options, callback);
+		this._requestPart2.call(this, options, callback);
 	}
 };
 

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -6,14 +6,13 @@
  */
 
 const
-	Cam = require('./cam').Cam
-	, events = require('events')
-	, guid = require('./utils').guid
-	, linerase = require('./utils').linerase
-	, parseSOAPString = require('./utils').parseSOAPString
-	, url = require('url')
-	, os = require('os')
-	;
+	Cam = require('./cam').Cam,
+	events = require('events'),
+	guid = require('./utils').guid,
+	linerase = require('./utils').linerase,
+	parseSOAPString = require('./utils').parseSOAPString,
+	url = require('url'),
+	os = require('os');
 
 /**
  * Discovery singleton
@@ -71,41 +70,42 @@ Discovery.probe = function(options, callback) {
 	}
 	callback = callback || function() {};
 
-	var cams = {}
-		, errors = []
-		, messageID = 'urn:uuid:' + (options.messageId || guid())
-		, request = Buffer.from(
+	var cams = {},
+		errors = [],
+		messageID = 'urn:uuid:' + (options.messageId || guid()),
+		request = Buffer.from(
 			'<Envelope xmlns="http://www.w3.org/2003/05/soap-envelope" xmlns:dn="http://www.onvif.org/ver10/network/wsdl">' +
-				'<Header>' +
-					'<wsa:MessageID xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">' + messageID + '</wsa:MessageID>' +
-					'<wsa:To xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">urn:schemas-xmlsoap-org:ws:2005:04:discovery</wsa:To>' +
-					'<wsa:Action xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</wsa:Action>' +
-				'</Header>' +
-				'<Body>' +
-					'<Probe xmlns="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
-						'<Types>dn:NetworkVideoTransmitter</Types>' +
-						'<Scopes />' +
-					'</Probe>' +
-				'</Body>' +
-			'</Envelope>'
-		)
-		, socket = require('dgram').createSocket('udp4');
+            '<Header>' +
+            '<wsa:MessageID xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">' + messageID + '</wsa:MessageID>' +
+            '<wsa:To xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">urn:schemas-xmlsoap-org:ws:2005:04:discovery</wsa:To>' +
+            '<wsa:Action xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing">http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</wsa:Action>' +
+            '</Header>' +
+            '<Body>' +
+            '<Probe xmlns="http://schemas.xmlsoap.org/ws/2005/04/discovery" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">' +
+            '<Types>dn:NetworkVideoTransmitter</Types>' +
+            '<Scopes />' +
+            '</Probe>' +
+            '</Body>' +
+            '</Envelope>'
+		),
+		socket = require('dgram').createSocket('udp4');
 
 	socket.on('error', function(err) {
 		Discovery.emit('error', err);
 		callback(err);
 	});
 
+	const httpOK200 = 200;
 	const listener = function(msg, rinfo) {
-		parseSOAPString(msg.toString(), function(err, data, xml) {
+		parseSOAPString(msg.toString(), function(err, data, xml, _statusCode) {
 			// TODO check for matching RelatesTo field and messageId
 			if (err || !data[0].probeMatches) {
 				errors.push(err || new Error('Wrong SOAP message from ' + rinfo.address + ':' + rinfo.port, xml));
 				/**
-				 * Indicates error response from device.
-				 * @event Discovery#error
-				 * @type {string}
-				 */
+                 * Indicates error response from device.
+                 * @event Discovery#error
+                 * @type {string}
+                 */
 				Discovery.emit('error', 'Wrong SOAP message from ' + rinfo.address + ':' + rinfo.port, xml);
 			} else {
 				data = linerase(data);
@@ -117,35 +117,34 @@ Discovery.probe = function(options, callback) {
 					var cam;
 					if (options.resolve !== false) {
 						// Create cam with one of the XAddrs uri
-						var camUris = data.probeMatches.probeMatch.XAddrs.split(' ').map(url.parse)
-							, camUri = matchXAddr(camUris, rinfo.address)
-						;
+						var camUris = data.probeMatches.probeMatch.XAddrs.split(' ').map(url.parse),
+							camUri = matchXAddr(camUris, rinfo.address);
 						cam = new Cam({
-							hostname: camUri.hostname
-							, port: camUri.port
-							, path: camUri.path
-							, urn: camAddr
+							hostname: camUri.hostname,
+							port: camUri.port,
+							path: camUri.path,
+							urn: camAddr
 						});
 						/**
-						 * All available XAddr fields from discovery
-						 * @name xaddrs
-						 * @memberOf Cam#
-						 * @type {Array.<Url>}
-						 */
+                         * All available XAddr fields from discovery
+                         * @name xaddrs
+                         * @memberOf Cam#
+                         * @type {Array.<Url>}
+                         */
 						cam.xaddrs = camUris;
 					} else {
 						cam = data;
 					}
 					cams[camAddr] = cam;
 					/**
-					 * Indicates discovered device.
-					 * @event Discovery#device
-					 * @type {Cam|object}
-					 */
+                     * Indicates discovered device.
+                     * @event Discovery#device
+                     * @type {Cam|object}
+                     */
 					Discovery.emit('device', cam, rinfo, xml);
 				}
 			}
-		});
+		}, httpOK200);
 	};
 
 	// If device is specified try to bind to that interface

--- a/lib/ptz.js
+++ b/lib/ptz.js
@@ -313,14 +313,14 @@ module.exports = function(Cam) {
 					, spaces: {
 						absolute: {
 							x: {
-								min: parseFloat(sp['absolutePanTiltPositionSpace'][0]['XRange'][0]['min'][0])
-								, max: parseFloat(sp['absolutePanTiltPositionSpace'][0]['XRange'][0]['max'][0])
-								, uri: sp['absolutePanTiltPositionSpace'][0]['URI']
+								min: (sp.absolutePanTiltPositionSpace) ? parseFloat(sp['absolutePanTiltPositionSpace'][0]['XRange'][0]['min'][0]) : 0
+								, max: (sp.absolutePanTiltPositionSpace) ? parseFloat(sp['absolutePanTiltPositionSpace'][0]['XRange'][0]['max'][0]) : 0
+								, uri: (sp.absolutePanTiltPositionSpace) ? sp['absolutePanTiltPositionSpace'][0]['URI'] : ''
 							}
 							, y: {
-								min: parseFloat(sp['absolutePanTiltPositionSpace'][0]['YRange'][0]['min'][0])
-								, max: parseFloat(sp['absolutePanTiltPositionSpace'][0]['YRange'][0]['max'][0])
-								, uri: sp['absolutePanTiltPositionSpace'][0]['URI']
+								min: (sp.absolutePanTiltPositionSpace) ? parseFloat(sp['absolutePanTiltPositionSpace'][0]['YRange'][0]['min'][0]) : 0
+								, max: (sp.absolutePanTiltPositionSpace) ? parseFloat(sp['absolutePanTiltPositionSpace'][0]['YRange'][0]['max'][0]) : 0
+								, uri: (sp.absolutePanTiltPositionSpace) ? sp['absolutePanTiltPositionSpace'][0]['URI'] : ''
 							}
 							, zoom: {
 								min: (sp.absoluteZoomPositionSpace) ? parseFloat(sp['absoluteZoomPositionSpace'][0]['XRange'][0]['min'][0]) : 0
@@ -330,14 +330,14 @@ module.exports = function(Cam) {
 						}
 						, relative: {
 							x: {
-								min: parseFloat(sp['relativePanTiltTranslationSpace'][0]['XRange'][0]['min'][0])
-								, max: parseFloat(sp['relativePanTiltTranslationSpace'][0]['XRange'][0]['max'][0])
-								, uri: sp['relativePanTiltTranslationSpace'][0]['URI']
+								min: (sp.relativePanTiltTranslationSpace) ? parseFloat(sp['relativePanTiltTranslationSpace'][0]['XRange'][0]['min'][0]) : 0
+								, max: (sp.relativePanTiltTranslationSpace) ? parseFloat(sp['relativePanTiltTranslationSpace'][0]['XRange'][0]['max'][0]) : 0
+								, uri: (sp.relativePanTiltTranslationSpace) ? sp['relativePanTiltTranslationSpace'][0]['URI'] : ''
 							}
 							, y: {
-								min: parseFloat(sp['relativePanTiltTranslationSpace'][0]['YRange'][0]['min'][0])
-								, max: parseFloat(sp['relativePanTiltTranslationSpace'][0]['YRange'][0]['max'][0])
-								, uri: sp['relativePanTiltTranslationSpace'][0]['URI']
+								min: (sp.relativePanTiltTranslationSpace) ? parseFloat(sp['relativePanTiltTranslationSpace'][0]['YRange'][0]['min'][0]) : 0
+								, max: (sp.relativePanTiltTranslationSpace) ? parseFloat(sp['relativePanTiltTranslationSpace'][0]['YRange'][0]['max'][0]) : 0
+								, uri: (sp.relativePanTiltTranslationSpace) ? sp['relativePanTiltTranslationSpace'][0]['URI'] : ''
 							}
 							, zoom: {
 								min: (sp.relativeZoomTranslationSpace) ? parseFloat(sp['relativeZoomTranslationSpace'][0]['XRange'][0]['min'][0]) : 0
@@ -347,14 +347,14 @@ module.exports = function(Cam) {
 						}
 						, continuous: {
 							x: {
-								min: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['XRange'][0]['min'][0])
-								, max: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['XRange'][0]['max'][0])
-								, uri: sp['continuousPanTiltVelocitySpace'][0]['URI']
+								min: (sp.continuousPanTiltVelocitySpace) ? parseFloat(sp['continuousPanTiltVelocitySpace'][0]['XRange'][0]['min'][0]) : 0
+								, max: (sp.continuousPanTiltVelocitySpace) ? parseFloat(sp['continuousPanTiltVelocitySpace'][0]['XRange'][0]['max'][0]) : 0
+								, uri: (sp.continuousPanTiltVelocitySpace) ? sp['continuousPanTiltVelocitySpace'][0]['URI'] : ''
 							}
 							, y: {
-								min: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['YRange'][0]['min'][0])
-								, max: parseFloat(sp['continuousPanTiltVelocitySpace'][0]['YRange'][0]['max'][0])
-								, uri: sp['continuousPanTiltVelocitySpace'][0]['URI']
+								min: (sp.continuousPanTiltVelocitySpace) ? parseFloat(sp['continuousPanTiltVelocitySpace'][0]['YRange'][0]['min'][0]) : 0
+								, max: (sp.continuousPanTiltVelocitySpace) ? parseFloat(sp['continuousPanTiltVelocitySpace'][0]['YRange'][0]['max'][0]) : 0
+								, uri: (sp.continuousPanTiltVelocitySpace) ? sp['continuousPanTiltVelocitySpace'][0]['URI'] : ''
 							}
 							, zoom: {
 								min: (sp.continuousZoomVelocitySpace) ? parseFloat(sp['continuousZoomVelocitySpace'][0]['XRange'][0]['min'][0]) : 0

--- a/lib/ptz.js
+++ b/lib/ptz.js
@@ -301,6 +301,10 @@ module.exports = function(Cam) {
 			var configOptions;
 			if (!err) {
 				var sp = data[0]['getConfigurationOptionsResponse'][0]['PTZConfigurationOptions'][0]['spaces'][0];
+
+				// [2022] ONVIF Cameras now support a wide range of Spaces including Sepherical Spaces and FieldOfView (FOV) spaces.
+				// To avoid breaking anything, continue to parse the FIRST space [0] for absolute, releative and continuous
+				// but add a new 'ptzspaces' array
 				configOptions = {
 					ptzTimeout: {
 						min: data[0]['getConfigurationOptionsResponse'][0]['PTZConfigurationOptions'][0]['PTZTimeout'][0]['min']
@@ -372,7 +376,32 @@ module.exports = function(Cam) {
 						}
 					}
 				};
-				if (this.configurations[configurationToken]) {
+				// Oct 2022 - Add parsing of the XML reply to handle the case where there are multiple Absolute and Relative Spaces
+				configOptions.ptzspaces = [];
+				for (const key of Object.keys(sp)) {
+					for (const item of sp[key]) {
+						let data = {
+							name: key,
+							uri: item.URI[0]
+						};
+						if (item.XRange) {
+							data.x = {
+								min: parseFloat(item.XRange[0].min[0]),
+								max: parseFloat(item.XRange[0].max[0])
+							};
+						}
+						if (item.YRange) {
+							data.y = {
+								min: parseFloat(item.YRange[0].min[0]),
+								max: parseFloat(item.YRange[0].max[0])
+							};
+						}
+
+						configOptions.ptzspaces.push(data);
+					}
+				}
+
+				if (this.configurations && this.configurations[configurationToken]) {
 					Object.assign(this.configurations[configurationToken], configOptions);
 				}
 			}
@@ -386,13 +415,15 @@ module.exports = function(Cam) {
 	 * /PTZ/ relative move
 	 * @param {object} options
 	 * @param {string} [options.profileToken=Cam#activeSource.profileToken]
-	 * @param {number} [options.x=0] Pan, float within -1 to 1
-	 * @param {number} [options.y=0] Tilt, float within -1 to 1
-	 * @param {number} [options.zoom=0] Zoom, float within 0 to 1
+	 * @param {number} [options.x=0] Pan, float. Min and Max values defined by the Space used (often -1 to +1)
+	 * @param {number} [options.y=0] Tilt, float. Min and Max values defined by the Space used (often -1 to +1)
+	 * @param {number} [options.xyspace] Optional geometry space to be used when not using the default space
+	 * @param {number} [options.zoom=0] Zoom, float. Min and Max values defined by the Space used (often -1 to +1)
+	 * @param {number} [options.zoomspace] Optional geometry space to be used when not using the default space
 	 * @param {object} [options.speed] If the speed argument is omitted, the default speed set by the PTZConfiguration will be used.
-	 * @param {number} [options.speed.x] Pan speed, float within 0 to 1
-	 * @param {number} [options.speed.y] Tilt speed, float within 0 to 1
-	 * @param {number} [options.speed.zoom] Zoom speed, float within 0 to 1
+	 * @param {number} [options.speed.x] Pan speed, float. Min and Max values defined by the Space used (often -0 to +1)
+	 * @param {number} [options.speed.y] Tilt speed, float. Min and Max values defined by the Space used (often -0 to +1)
+	 * @param {number} [options.speed.zoom] Zoom speed, float. Min and Max values defined by the Space used (often -0 to +1)
 	 * @param {Cam~RequestCallback} [callback]
 	 */
 	Cam.prototype.relativeMove = function(options, callback) {
@@ -518,18 +549,24 @@ module.exports = function(Cam) {
 	 * Create ONVIF soap vector
 	 * @param [ptz.x]
 	 * @param [ptz.y]
+	 * @param [ptz.xyspace]
 	 * @param [ptz.zoom]
+	 * @param [ptz.zoomspace]
 	 * @return {string}
 	 * @private
 	 */
 	Cam.prototype._panTiltZoomVectors = function(ptz) {
+		// add leading ' ' (space) to xyspace and zspace
+		const xyspace = (ptz.xyspace !== undefined ? ' space="' + ptz.xyspace + '"' : '');
+		const zoomspace = (ptz.zoomspace !== undefined ? ' space="' + ptz.zoomspace + '"' : '');
+
 		return ptz
 			?
 			(ptz.x !== undefined && ptz.y !== undefined
-				? '<PanTilt x="' + ptz.x + '" y="' + ptz.y + '" xmlns="http://www.onvif.org/ver10/schema"/>'
+				? '<PanTilt x="' + ptz.x + '" y="' + ptz.y + '"' + xyspace + ' xmlns="http://www.onvif.org/ver10/schema"/>'
 				: '') +
 			(ptz.zoom !== undefined
-				? '<Zoom x="' + ptz.zoom + '" xmlns="http://www.onvif.org/ver10/schema"/>'
+				? '<Zoom x="' + ptz.zoom + '"' + zoomspace + ' xmlns="http://www.onvif.org/ver10/schema"/>'
 				: '')
 			: '';
 	};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,11 +5,10 @@
  * @licence MIT
  */
 
-const xml2js = require('xml2js')
-	, numberRE = /^-?([1-9]\d*|0)(\.\d*)?$/
-	, dateRE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?Z$/
-	, prefixMatch = /(?!xmlns)^.*:/
-	;
+const xml2js = require('xml2js'),
+	numberRE = /^-?([1-9]\d*|0)(\.\d*)?$/,
+	dateRE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(.\d+)?Z$/,
+	prefixMatch = /(?!xmlns)^.*:/;
 
 /**
  * Parse SOAP object to pretty JS-object
@@ -44,21 +43,22 @@ const linerase = function(xml) {
  * @property {?Error} error
  * @property {object} SOAP response
  * @property {string} raw XML
+ * @property {number} HTTP Status Code
  */
 
 /**
  * Parse SOAP response
  * @param {string} xml
  * @param {ParseSOAPStringCallback} callback
+ * @param {number} statusCode. This is passed in so it can be passed back out to the callback
  */
-const parseSOAPString = function(xml, callback) {
+const parseSOAPString = function(xml, callback, statusCode) {
 	/* Filter out xml name spaces */
-	xml = xml.replace(/xmlns([^=]*?)=(".*?")/g,'');
+	xml = xml.replace(/xmlns([^=]*?)=(".*?")/g, '');
 
 	try {
 		xml2js.parseString(
-			xml
-			, {
+			xml, {
 				tagNameProcessors: [function(str) {
 					str = str.replace(prefixMatch, '');
 					var secondLetter = str.charAt(1);
@@ -68,10 +68,10 @@ const parseSOAPString = function(xml, callback) {
 						return str;
 					}
 				}]
-			}
-			, function(err, result) {
+			},
+			function(err, result) {
 				if (!result || !result['envelope'] || !result['envelope']['body']) {
-					callback(new Error('Wrong ONVIF SOAP response'), null, xml);
+					callback(new Error('Wrong ONVIF SOAP response'), null, xml, statusCode);
 				} else {
 					if (!err && result['envelope']['body'][0]['fault']) {
 						var fault = result['envelope']['body'][0]['fault'][0];
@@ -100,12 +100,12 @@ const parseSOAPString = function(xml, callback) {
 						// console.error('Fault:', reason, detail);
 						err = new Error('ONVIF SOAP Fault: ' + (reason) + (detail));
 					}
-					callback(err, result['envelope']['body'], xml);
+					callback(err, result['envelope']['body'], xml, statusCode);
 				}
 			}
 		);
 	} catch (err) {
-		callback(err, '', xml);
+		callback(err, '', xml, statusCode);
 	}
 };
 
@@ -122,7 +122,7 @@ const guid = function() {
 };
 
 module.exports = {
-	linerase: linerase
-	, parseSOAPString: parseSOAPString
-	, guid: guid
+	linerase: linerase,
+	parseSOAPString: parseSOAPString,
+	guid: guid
 };


### PR DESCRIPTION
It looks like SOAP 1.2 requires ths field and 1 ONVIF camera requires it
The code is not very efficient. It parses the XML to be sent to generate
the action string. It would be better for action strings to be hard coded
throughout the library