### PR TITLE
Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ The options are:
 
 - `x` Pan, number or a string within -1 to 1, optional
 - `y` Tilt, number or a string within -1 to 1, optional
-- `zoom` Zoom, number or a string within -1 to 1, optional
+- `zoom` Zoom, number or a string within 0 to 1, optional
 - `speed` An object with properties
   * `x` Pan speed
   * `y` Tilt speed
@@ -319,7 +319,7 @@ The options are:
 
 - `x` Pan, number or a string within -1 to 1, optional
 - `y` Tilt, number or a string within -1 to 1, optional
-- `zoom` Zoom, number or a string within -1 to 1, optional
+- `zoom` Zoom, number or a string within 0 to 1, optional
 - `speed` An object with properties
   * `x` Pan speed
   * `y` Tilt speed
@@ -334,9 +334,9 @@ Callback is optional and means essentially nothing
 
 The options are:
 
-- `x` Pan velocity, number or a string within -1 to 1, optional
-- `y` Tilt velocity, number or a string within -1 to 1, optional
-- `zoom` Zoom velocity, number or a string within -1 to 1, optional
+- `x` Pan velocity, number or a string within 0 to 1, optional
+- `y` Tilt velocity, number or a string within 0 to 1, optional
+- `zoom` Zoom velocity, number or a string within 0 to 1, optional
 - `timeout` Timeout in milliseconds, number. If timeout is omitted, movement will continue until `stop` command
 
 ### stop(options, callback)

--- a/README.md
+++ b/README.md
@@ -334,9 +334,9 @@ Callback is optional and means essentially nothing
 
 The options are:
 
-- `x` Pan velocity, number or a string within 0 to 1, optional
-- `y` Tilt velocity, number or a string within 0 to 1, optional
-- `zoom` Zoom velocity, number or a string within 0 to 1, optional
+- `x` Pan velocity, number or a string within -1 to 1, optional
+- `y` Tilt velocity, number or a string within -1 to 1, optional
+- `zoom` Zoom velocity, number or a string within -1 to 1, optional
 - `timeout` Timeout in milliseconds, number. If timeout is omitted, movement will continue until `stop` command
 
 ### stop(options, callback)

--- a/README.md
+++ b/README.md
@@ -277,9 +277,9 @@ The options are:
 
 * `profileToken` (optional) - defines media profile to use and will define the configuration of the content of the stream. Default is `#activeSource.profileToken`
 * `speed` An object with properties
-  - `x` Pan speed
-  - `y` Tilt speed
-  - `zoom` Zoom speed
+  - `x` Pan speed, float within 0 to 1
+  - `y` Tilt speed, float within 0 to 1
+  - `zoom` Zoom speed, float within 0 to 1
 
   If the speed option is omitted, the default speed set by the PTZConfiguration will be used.
 
@@ -304,9 +304,9 @@ The options are:
 - `y` Tilt, number or a string within -1 to 1, optional
 - `zoom` Zoom, number or a string within 0 to 1, optional
 - `speed` An object with properties
-  * `x` Pan speed
-  * `y` Tilt speed
-  * `zoom` Zoom speed
+  * `x` Pan speed, float within 0 to 1
+  * `y` Tilt speed, float within 0 to 1
+  * `zoom` Zoom speed, float within 0 to 1
 
   If the speed option is omitted, the default speed set by the PTZConfiguration will be used.
 
@@ -321,9 +321,9 @@ The options are:
 - `y` Tilt, number or a string within -1 to 1, optional
 - `zoom` Zoom, number or a string within 0 to 1, optional
 - `speed` An object with properties
-  * `x` Pan speed
-  * `y` Tilt speed
-  * `zoom` Zoom speed
+  * `x` Pan speed, float within 0 to 1
+  * `y` Tilt speed, float within 0 to 1
+  * `zoom` Zoom speed, float within 0 to 1
 
   If the speed option is omitted, the default speed set by the PTZConfiguration will be used.
 

--- a/lib/ptz.js
+++ b/lib/ptz.js
@@ -452,9 +452,9 @@ module.exports = function(Cam) {
 	 * /PTZ/ Operation for continuous Pan/Tilt and Zoom movements
 	 * @param options
 	 * @param {string} [options.profileToken=Cam#activeSource.profileToken]
-	 * @param {number} [options.x=0] pan velocity, float within 0 to 1
-	 * @param {number} [options.y=0] tilt velocity, float within 0 to 1
-	 * @param {number} [options.zoom=0] zoom velocity, float within 0 to 1
+	 * @param {number} [options.x=0] pan velocity, float within -1 to 1
+	 * @param {number} [options.y=0] tilt velocity, float within -1 to 1
+	 * @param {number} [options.zoom=0] zoom velocity, float within -1 to 1
 	 * @param {boolean} [options.onlySendPanTilt] Only send the Pan and Tilt values in the ONVIF XML. Zoom not sent in the XML
 	 * @param {boolean} [options.onlySendZoom] Only send the Zoom values in the ONVIF XML. PanTilt not sent in the XML
 	 * Somy cameras do not accept X and Y and Zoom all at the same time


### PR DESCRIPTION
Hi.

Im not sure why there are differences between the code comments and the docs but shouldn't the docs be auto generated from the code comments to avoid this exact problem? 🤔

Thanks.