### PR TITLE
Make legacy version common tests compliant

### DIFF
--- a/IMPLEMENTED.md
+++ b/IMPLEMENTED.md
@@ -37,8 +37,8 @@
 - [ ] getAudioSourceConfigurations
 - [ ] getAudioSources
 - [x] getCapabilities
-- [ ] getConfigurationOptions
-- [ ] getConfigurations
+- [x] getConfigurationOptions
+- [x] getConfigurations
 - [ ] getCurrentImagingPreset
 - [x] getDeviceInformation
 - [ ] getDNS
@@ -51,7 +51,7 @@
 - [ ] getNetworkDefaultGateway
 - [ ] getNetworkInterfaces
 - [ ] getNetworkProtocols
-- [ ] getNodes
+- [x] getNodes
 - [ ] getNTP
 - [ ] getOSDOptions
 - [ ] getOSDs
@@ -99,5 +99,5 @@
 - [ ] setVideoEncoderConfiguration
 - [ ] stop
 - [ ] subscribe
-- [ ] systemReboot
+- [x] systemReboot
 - [ ] unsubscribe

--- a/legacyTest/common.js
+++ b/legacyTest/common.js
@@ -120,7 +120,7 @@ describe('Common functions', () => {
 				assert.strictEqual(err, null);
 				assert.ok(cam.capabilities || cam.services);
 				if (synthTest) {
-					assert.ok(cam.uri.ptz);
+					assert.ok(cam.uri.PTZ);
 				}
 				assert.ok(cam.uri.media);
 				assert.ok(cam.videoSources);
@@ -277,7 +277,7 @@ describe('Common functions', () => {
 			});
 		});
 		it('should store PTZ link in ptzUri property', (done) => {
-			assert.strictEqual(cam.uri.ptz.href, cam.capabilities.PTZ.XAddr);
+			assert.strictEqual(cam.uri.PTZ.href, cam.capabilities.PTZ.XAddr);
 			done();
 		});
 		it('should store uri links for extensions', (done) => {

--- a/src/legacy/cam.ts
+++ b/src/legacy/cam.ts
@@ -3,7 +3,9 @@
  */
 
 import { EventEmitter } from 'events';
-import { Onvif, OnvifRequestOptions, SetSystemDateAndTimeOptions } from '../onvif';
+import {
+  Onvif, OnvifRequestOptions, ReferenceToken, SetSystemDateAndTimeOptions,
+} from '../onvif';
 import { GetSnapshotUriOptions, GetStreamUriOptions } from '../media';
 
 type Callback = (error: any, result?: any) => void;
@@ -37,6 +39,7 @@ export class Cam extends EventEmitter {
   get serviceCapabilities() { return this.onvif.device.serviceCapabilities; }
   get deviceInformation() { return this.onvif.deviceInformation; }
   get nodes() { return this.onvif.ptz.nodes; }
+  get configurations() { return this.onvif.ptz.configurations; }
 
   connect(callback: Callback) {
     this.onvif.connect().then((result) => callback(null, result)).catch(callback);
@@ -74,7 +77,8 @@ export class Cam extends EventEmitter {
   }
 
   getServiceCapabilities(callback: Callback) {
-    this.onvif.device.getServiceCapabilities().then((result) => callback(null, result)).catch(callback);
+    this.onvif.device.getServiceCapabilities()
+      .then((result) => callback(null, result)).catch(callback);
   }
 
   getActiveSources(callback: Callback) {
@@ -88,20 +92,24 @@ export class Cam extends EventEmitter {
   }
 
   getServices(includeCapability: boolean, callback: Callback) {
-    this.onvif.device.getServices(includeCapability).then((result) => callback(null, result)).catch(callback);
+    this.onvif.device.getServices(includeCapability)
+      .then((result) => callback(null, result)).catch(callback);
   }
 
   getDeviceInformation(callback: Callback) {
-    this.onvif.device.getDeviceInformation().then((result) => callback(null, result)).catch(callback);
+    this.onvif.device.getDeviceInformation()
+      .then((result) => callback(null, result)).catch(callback);
   }
 
   getStreamUri(options: GetStreamUriOptions, callback: Callback): void
   getStreamUri(callback: Callback): void
   getStreamUri(options: GetStreamUriOptions | Callback, callback?: Callback) {
     if (callback) {
-      this.onvif.media.getStreamUri(options as GetStreamUriOptions).then((result) => callback(null, result)).catch(callback);
+      this.onvif.media.getStreamUri(options as GetStreamUriOptions)
+        .then((result) => callback(null, result)).catch(callback);
     }
-    this.onvif.media.getStreamUri().then((result) => (options as Callback)(null, result)).catch(options as Callback);
+    this.onvif.media.getStreamUri()
+      .then((result) => (options as Callback)(null, result)).catch(options as Callback);
   }
 
   getSnapshotUri(options: GetSnapshotUriOptions, callback: Callback): void
@@ -117,5 +125,18 @@ export class Cam extends EventEmitter {
 
   getNodes(callback: Callback) {
     this.onvif.ptz.getNodes().then((result) => callback(null, result)).catch(callback);
+  }
+
+  getConfigurations(callback: Callback) {
+    this.onvif.ptz.getConfigurations().then((result) => callback(null, result)).catch(callback);
+  }
+
+  getConfigurationOptions(configurationToken: ReferenceToken, callback: Callback) {
+    this.onvif.ptz.getConfigurationOptions({ configurationToken })
+      .then((result) => callback(null, result)).catch(callback);
+  }
+
+  systemReboot(callback: Callback) {
+    this.onvif.device.systemReboot().then((result) => callback(null, result)).catch(callback);
   }
 }

--- a/src/media.ts
+++ b/src/media.ts
@@ -292,19 +292,23 @@ export interface VideoAnalyticsConfiguration {
   ruleEngineConfiguration: RuleEngineConfiguration;
 }
 
+export interface Vector2D {
+  x: number;
+  y: number;
+}
+
+export interface Vector1D {
+  x: number;
+}
+
 export interface PTZSpeed {
   /**
    * Pan and tilt speed. The x component corresponds to pan and the y component to tilt.
    * If omitted in a request, the current (if any) PanTilt movement should not be affected
    */
-  panTilt: {
-    x: number;
-    y: number;
-  };
+  panTilt: Vector2D;
   /** A zoom speed. If omitted in a request, the current (if any) Zoom movement should not be affected */
-  zoom: {
-    x: number;
-  }
+  zoom: Vector1D;
 }
 
 export interface Range {
@@ -368,11 +372,11 @@ export interface PTZConfiguration {
    */
   useCount: number;
   /** The optional acceleration ramp used by the device when moving */
-  moveRamp: number;
+  moveRamp?: number;
   /** The optional acceleration ramp used by the device when recalling presets */
-  presetRamp: number;
+  presetRamp?: number;
   /** The optional acceleration ramp used by the device when executing PresetTours */
-  presetTourRamp: number;
+  presetTourRamp?: number;
   /** A mandatory reference to the PTZ Node that the PTZ Configuration belongs to */
   nodeToken: string;
   /** If the PTZ Node supports absolute Pan/Tilt movements, it shall specify one Absolute Pan/Tilt Position Space as default */

--- a/src/onvif.ts
+++ b/src/onvif.ts
@@ -38,7 +38,7 @@ export interface OnvifOptions {
 }
 
 export interface OnvifServices {
-  ptz?: URL;
+  PTZ?: URL;
   analyticsDevice?: URL;
   device?: URL;
   deviceIO?: URL;

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,4 +1,4 @@
-import { Onvif, Discovery } from './index';
+import { Onvif, Discovery, Profile } from './index';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const serverMockup = require('../test/serverMockup');
@@ -17,9 +17,11 @@ const serverMockup = require('../test/serverMockup');
   const profiles = await cam.media.getProfiles();
   console.log((await cam.device.getDeviceInformation()).firmwareVersion);
   console.log((await cam.device.getHostname()));
+  // console.log(((await cam.media.getProfiles())[0] as Profile).PTZConfiguration);
+  console.log(await cam.ptz.getConfigurations());
+  console.log(await cam.device.systemReboot());
   // console.log(profiles);
   // Discovery.on('device', console.log);
   // const cams = await Discovery.probe({ timeout : 1000 });
   // console.log(cams);
-  serverMockup.close();
-})().catch(console.error);
+})().catch(console.error).finally(serverMockup.close);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,7 +12,6 @@ export function linerase(xml: any): any {
     if (xml.length > 1) {
       return xml.map(linerase);
     }
-    // eslint-disable-next-line no-param-reassign
     [xml] = xml;
   }
   if (typeof xml === 'object') {


### PR DESCRIPTION
Add `getConfigurationOptions`, `getConfigurations`, `getNodes` `systemReboot` methods and make legacy version common tests compliant