### PR TITLE
fix(209): add type class field to generate typescript definitions

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -30,6 +30,7 @@ const http = require('http'),
 
 /**
  * Camera class
+ * @type Class
  * @param {object} options
  * @param {boolean} options.useSecure Set true if `https:`, defaults to false
  * @param {object} options.secureOpts Set options for https like ca, cert, ciphers, rejectUnauthorized, secureOptions, secureProtocol, etc.


### PR DESCRIPTION
For the `npx -p typescript tsc lib/cam.js --declaration --allowJs --emitDeclarationOnly --outDir types` command.
Maybe types will be added in the master for `v.0.6`, but I'm still working on another branch which is written in ts