### PR TITLE
Add support for focus control commands: GetMoveOptions, Move, Stop

### DIFF
--- a/lib/imaging.js
+++ b/lib/imaging.js
@@ -409,4 +409,148 @@ module.exports = function(Cam) {
 			}
 		}.bind(this));
 	};
+
+	/**
+	 * Get the move options to be used in the focus move command for a given video source
+	 * @param {Object} options
+	 * @param {string} [options.token=Cam#activeSource.sourceToken] videoSourceToken
+	 * @param {function} [callback]
+	 */
+	Cam.prototype.getMoveOptions = function(options, callback) {
+		if (typeof callback === 'undefined') {
+			callback = options;
+			options = {};
+		}
+		this._request({
+			service: 'imaging'
+			, body: this._envelopeHeader() +
+				'<GetMoveOptions xmlns="http://www.onvif.org/ver20/imaging/wsdl">' +
+				'<VideoSourceToken>' + (options.token || this.activeSource.sourceToken) + '</VideoSourceToken>' +
+				'</GetMoveOptions>' +
+				this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				let jsonData = linerase(data),
+					respData = {};
+				if (jsonData && jsonData.getMoveOptionsResponse && jsonData.getMoveOptionsResponse.moveOptions) {
+					respData = jsonData.getMoveOptionsResponse.moveOptions;
+				}
+				// Empty response on success
+				callback.call(this, err, respData, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * /Focus/ The command moves the focus lens in an absolute, a relative, or in a continuous manner from its current position.
+	 * @param {object} options The supported move options are signaled via the GetMoveOptions command
+	 * @param {string} [options.token=Cam#activeSource.sourceToken] videoSourceToken
+	 * @param {object} [options.absolute] absolute movement
+	 * @param {number} [options.absolute.position] Min and Max values defined by the GetMoveOptions if support the absolute movement
+	 * @param {number} [options.absolute.speed] If the speed argument is omitted, the default speed set by the ImagingSetting will be used.
+	 * @param {object} [options.relative] relative movement
+	 * @param {number} [options.relative.distance] Min and Max values defined by the GetMoveOptions if support the relative movement
+	 * @param {number} [options.relative.speed] If the speed argument is omitted, the default speed set by the ImagingSetting will be used.
+	 * @param {object} [options.continuous] continuous move until the focus lens touches the bandwidth or gets a stop command
+	 * @param {number} [options.continuous.speed] Min and Max values defined by the GetMoveOptions if support the continuous movement
+	 * @param callback
+	 */
+	Cam.prototype.move = function(options, callback) {
+		this._request({
+			service: 'imaging'
+			, body: this._envelopeHeader() +
+			'<Move xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
+				'<VideoSourceToken  xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
+				(options.token || this.activeSource.sourceToken) +
+				'</VideoSourceToken>' +
+
+				'<Focus xmlns="http://www.onvif.org/ver10/schema">' +
+				(
+					options.absolute ?
+						(
+							'<Absolute xmlns="http://www.onvif.org/ver10/schema">' +
+							(
+								options.absolute.position ?
+									(
+										'<Position xmlns="http://www.onvif.org/ver10/schema">' + options.absolute.position + '</Position>'
+									) : ''
+							)
+							+
+							(
+								options.absolute.speed ?
+									(
+										'<Speed xmlns="http://www.onvif.org/ver10/schema">' + options.absolute.speed + '</Speed>'
+									) : ''
+							)
+							+ '</Absolute>'
+						) : ''
+				)
+				+
+				(
+					options.relative ?
+						(
+							'<Relative xmlns="http://www.onvif.org/ver10/schema">' +
+							(
+								options.relative.distance ?
+									(
+										'<Distance xmlns="http://www.onvif.org/ver10/schema">' + options.relative.distance + '</Distance>'
+									) : ''
+							)
+							+
+							(
+								options.relative.speed ?
+									(
+										'<Speed xmlns="http://www.onvif.org/ver10/schema">' + options.relative.speed + '</Speed>'
+									) : ''
+							)
+							+ '</Relative>'
+						) : ''
+				)
+				+
+				(
+					options.continuous ?
+						(
+							'<Continuous xmlns="http://www.onvif.org/ver10/schema">' +
+							(
+								options.continuous.speed ?
+									(
+										'<Speed xmlns="http://www.onvif.org/ver10/schema">' + options.continuous.speed + '</Speed>'
+									) : ''
+							)
+							+ '</Continuous>'
+						) : ''
+				)
+				+
+				'</Focus>' +
+			'</Move>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data).MoveResponse, xml);
+			}
+		}.bind(this));
+	};
+
+	/**
+	 * Stop the ongoing focus movements for a given video source
+	 * @param {Object} options
+	 * @param {string} [options.token=Cam#activeSource.sourceToken] videoSourceToken
+	 * @param callback
+	 */
+	Cam.prototype.stop = function(options, callback) {
+		this._request({
+			service: 'imaging'
+			, body: this._envelopeHeader() +
+			'<Stop xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
+				'<VideoSourceToken  xmlns="http://www.onvif.org/ver20/imaging/wsdl" >' +
+				(options.token || this.activeSource.sourceToken) +
+				'</VideoSourceToken>' +
+			'</Stop>' +
+			this._envelopeFooter()
+		}, function(err, data, xml) {
+			if (callback) {
+				callback.call(this, err, err ? null : linerase(data).StopResponse, xml);
+			}
+		}.bind(this));
+	};
 };

--- a/lib/imaging.js
+++ b/lib/imaging.js
@@ -416,7 +416,7 @@ module.exports = function(Cam) {
 	 * @param {string} [options.token=Cam#activeSource.sourceToken] videoSourceToken
 	 * @param {function} [callback]
 	 */
-	Cam.prototype.getMoveOptions = function(options, callback) {
+	Cam.prototype.imagingGetMoveOptions = function(options, callback) {
 		if (typeof callback === 'undefined') {
 			callback = options;
 			options = {};
@@ -442,20 +442,20 @@ module.exports = function(Cam) {
 	};
 
 	/**
-	 * /Focus/ The command moves the focus lens in an absolute, a relative, or in a continuous manner from its current position.
+	 * The command moves the focus lens in an absolute, a relative, or in a continuous manner from its current position.
 	 * @param {object} options The supported move options are signaled via the GetMoveOptions command
 	 * @param {string} [options.token=Cam#activeSource.sourceToken] videoSourceToken
-	 * @param {object} [options.absolute] absolute movement
+	 * @param {object} [options.absolute] Absolute movement
 	 * @param {number} [options.absolute.position] Min and Max values defined by the GetMoveOptions if support the absolute movement
 	 * @param {number} [options.absolute.speed] If the speed argument is omitted, the default speed set by the ImagingSetting will be used.
-	 * @param {object} [options.relative] relative movement
+	 * @param {object} [options.relative] Relative movement
 	 * @param {number} [options.relative.distance] Min and Max values defined by the GetMoveOptions if support the relative movement
 	 * @param {number} [options.relative.speed] If the speed argument is omitted, the default speed set by the ImagingSetting will be used.
-	 * @param {object} [options.continuous] continuous move until the focus lens touches the bandwidth or gets a stop command
+	 * @param {object} [options.continuous] Continuous move until the focus lens reaches its limits or gets a stop command
 	 * @param {number} [options.continuous.speed] Min and Max values defined by the GetMoveOptions if support the continuous movement
 	 * @param callback
 	 */
-	Cam.prototype.move = function(options, callback) {
+	Cam.prototype.imagingMove = function(options, callback) {
 		this._request({
 			service: 'imaging'
 			, body: this._envelopeHeader() +
@@ -537,7 +537,7 @@ module.exports = function(Cam) {
 	 * @param {string} [options.token=Cam#activeSource.sourceToken] videoSourceToken
 	 * @param callback
 	 */
-	Cam.prototype.stop = function(options, callback) {
+	Cam.prototype.imagingStop = function(options, callback) {
 		this._request({
 			service: 'imaging'
 			, body: this._envelopeHeader() +


### PR DESCRIPTION
This change follows Onvif ver20 imaging.wsdl to implement these Focus operations APIs in the imaging.js file:
1. GetMoveOptions
2. Move
3. Stop

Please feel free to contact me if you have any questions.
Thank you.

Best Regards,
Walker
