### PR TITLE
Add callback call check

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -305,7 +305,7 @@ module.exports = function(Cam) {
 				this.removeAllListeners('event'); // We can subscribe again only if there is no 'event' listener
 				var data = linerase(res).unsubscribeResponse;
 			}
-			if (callback) {
+			if (callback && callback.call) {
 				callback.call(this, err, data, xml);
 			}
 		}.bind(this));


### PR DESCRIPTION
I see a crash when called unsubscribed without callback to prevent a crash I added a check

```
2023-10-20 11:04:50.893 - error: tapo.0 (681712) uncaught exception: callback.call is not a function
2023-10-20 11:04:50.894 - error: tapo.0 (681712) TypeError: callback.call is not a function
at Cam. (/opt/iobroker/node_modules/onvif/lib/events.js:309:14)
at parseSOAPString (/opt/iobroker/node_modules/onvif/lib/utils.js:108:3)
at IncomingMessage. (/opt/iobroker/node_modules/onvif/lib/cam.js:297:4)
at IncomingMessage.emit (node:events:526:35)
at IncomingMessage.emit (node:domain:489:12)
at endReadableNT (node:internal/streams/readable:1359:12)
at processTicksAndRejections (node:internal/process/task_queues:82:21)
```