### PR TITLE
adds retry when pull subscriptions fails

### DIFF
--- a/lib/cam.js
+++ b/lib/cam.js
@@ -86,6 +86,7 @@ var Cam = function(options, callback) {
 	this.path = options.path || '/onvif/device_service';
 	this.timeout = options.timeout || 120000;
 	this.agent = options.agent || false;
+	this.eventReconnectms = options.eventReconnectms;
 	/**
 	 * Force using hostname and port from constructor for the services
 	 * @type {boolean}

--- a/lib/events.js
+++ b/lib/events.js
@@ -349,6 +349,8 @@ module.exports = function(Cam) {
 				this.createPullPointSubscription(function(error) {
 					if (!error) {
 						this._eventPull();
+					} else if (this.eventReconnectms) {
+						setTimeout(() => this._eventRequest(), this.eventReconnectms);
 					}
 				}.bind(this));
 			} else {


### PR DESCRIPTION
Hi, I am running https://shinobi.video/ which uses this library and have noticed that sometimes the ONVIF events don't get triggered. I narrowed this down to when there is a connection disruption e.g. my router updates or the camera is restarted.

This Pull Requests adds a retry mechanism if the connection fails. I have added a configurable wait time and used that as a kind of feature flag so this change is more backwards compatible.

I struggled to write tests for this due to the timeout and I think the mock server being in an external process. If someone could guide me the best way to test this I would be happy to write some tests.

I have tested this locally adding a listener, restarting my camera and then seeing if events continue to flow