### PR TITLE
SetNTP is not working with DNS due to a missing schema version URL

### DIFF
--- a/lib/device.js
+++ b/lib/device.js
@@ -89,8 +89,8 @@ module.exports = function(Cam) {
 					`<Type xmlns="http://www.onvif.org/ver10/schema">${  NTPManual.type  }</Type>${ 
 					 NTPManual.IPv4Address ? `<IPv4Address xmlns="http://www.onvif.org/ver10/schema">${  NTPManual.IPv4Address  }</IPv4Address>` : '' 
 					 }${NTPManual.IPv6Address ? `<IPv6Address xmlns="http://www.onvif.org/ver10/schema">${  NTPManual.IPv6Address  }</IPv6Address>` : '' 
-					 }${NTPManual.DNSname ? `<DNSname>${  NTPManual.DNSname  }</DNSname>` : '' 
-					 }${NTPManual.extension ? `<Extension>${  NTPManual.extension  }</Extension>` : '' 
+					 }${NTPManual.DNSname ? `<DNSname xmlns="http://www.onvif.org/ver10/schema">${  NTPManual.DNSname  }</DNSname>` : '' 
+					 }${NTPManual.extension ? `<Extension xmlns="http://www.onvif.org/ver10/schema">${  NTPManual.extension  }</Extension>` : '' 
 				}</NTPManual>` : '');
 			});
 		}


### PR DESCRIPTION
SetNTP is not working with DNS due to a missing schema version URL
Result bad Request 400 

I added  xmlns="http://www.onvif.org/ver10/schema" to DNSname tag 