### PR TITLE
media2 support for videoencoders 

### DIFF
--- a/lib/media.js
+++ b/lib/media.js
@@ -304,13 +304,15 @@ module.exports = function(Cam) {
 		} else if (!(options && (options.configurationToken || options.profileToken))) {
 			return callback(new Error("'options' must have one or both 'configurationToken' or 'profileToken'"));
 		}
+		const service = this.media2Support ? 'media2' : 'media';
+		const xmlns = this.media2Support? 'http://www.onvif.org/ver20/media/wsdl': 'http://www.onvif.org/ver10/media/wsdl';
 		this._request({
 			service: 'media'
 			, body: this._envelopeHeader() +
 			(
 				(options) ?
 					(
-						'<GetVideoEncoderConfigurationOptions xmlns="http://www.onvif.org/ver10/media/wsdl">' +
+						`<GetVideoEncoderConfigurationOptions xmlns="${xmlns}">` +
 					(
 						(options.configurationToken)
 							? '<ConfigurationToken>' + options.configurationToken + '</ConfigurationToken>'
@@ -323,7 +325,7 @@ module.exports = function(Cam) {
 					) +
 					'</GetVideoEncoderConfigurationOptions>'
 					)
-					: '<GetVideoEncoderConfigurationOptions xmlns="http://www.onvif.org/ver10/media/wsdl" />'
+					: `<GetVideoEncoderConfigurationOptions xmlns="${xmlns}">`
 			) +
 			this._envelopeFooter()
 		}, function(err, data, xml) {
@@ -338,10 +340,13 @@ module.exports = function(Cam) {
 	 * @param {Cam~VideoEncoderConfigurationsCallback} callback
 	 */
 	Cam.prototype.getVideoEncoderConfigurations = function(callback) {
+
+		const service = this.media2Support ? 'media2' : 'media';
+		const xmlns = this.media2Support? 'http://www.onvif.org/ver20/media/wsdl': 'http://www.onvif.org/ver10/media/wsdl';
 		this._request({
-			service: 'media'
+			service: service
 			, body: this._envelopeHeader() +
-			'<GetVideoEncoderConfigurations xmlns="http://www.onvif.org/ver10/media/wsdl"/>' +
+			`<GetVideoEncoderConfigurations xmlns="${xmlns}"/>` +
 			this._envelopeFooter()
 		}, function(err, data, xml) {
 			if (!err) {
@@ -392,11 +397,13 @@ module.exports = function(Cam) {
 		if (!options.token && !(options.$ && options.$.token)) {
 			return callback(new Error('No video encoder configuration token is present!'));
 		}
+		const service = this.media2Support ? 'media2' : 'media';
+		const xmlns = this.media2Support? 'http://www.onvif.org/ver20/media/wsdl': 'http://www.onvif.org/ver10/media/wsdl';
 		this._request({
-			service: 'media',
+			service: service,
 			body: this._envelopeHeader() +
-			'<SetVideoEncoderConfiguration xmlns="http://www.onvif.org/ver10/media/wsdl">' +
-				'<Configuration token = "' + (options.token || options.$.token) + '">' +
+			`<SetVideoEncoderConfiguration xmlns="${xmlns}">`+
+				`<Configuration token="${options.token ?? options.$.token}"` + (options.$.GovLength?` GovLength="${options.$.GovLength}"`:'')  + (options.$.Profile?` Profile="${options.$.Profile}"`:'')  +'>' +
 				( options.name ? '<Name xmlns="http://www.onvif.org/ver10/schema">' + options.name + '</Name>' : '' ) +
 				( options.useCount ? '<UseCount xmlns="http://www.onvif.org/ver10/schema">' + options.useCount + '</UseCount>' : '' ) +
 				( options.encoding ? '<Encoding xmlns="http://www.onvif.org/ver10/schema">' + options.encoding + '</Encoding>' : '' ) +
@@ -407,7 +414,7 @@ module.exports = function(Cam) {
 				'</Resolution>' : '') +
 				( options.quality ? '<Quality xmlns="http://www.onvif.org/ver10/schema">' + options.quality + '</Quality>' : '' ) +
 				( options.rateControl ?
-					'<RateControl xmlns="http://www.onvif.org/ver10/schema">' +
+					`<RateControl ConstantBitRate="${options.rateControl.$?.ConstantBitRate}"  xmlns="http://www.onvif.org/ver10/schema"> ` +
 					( options.rateControl.frameRateLimit ? '<FrameRateLimit>' + options.rateControl.frameRateLimit + '</FrameRateLimit>' : '' ) +
 					( options.rateControl.encodingInterval ? '<EncodingInterval>' + options.rateControl.encodingInterval + '</EncodingInterval>' : '' ) +
 					( options.rateControl.bitrateLimit ? '<BitrateLimit>' + options.rateControl.bitrateLimit + '</BitrateLimit>' : '' ) +
@@ -440,7 +447,7 @@ module.exports = function(Cam) {
 					options.sessionTimeout +
 				'</SessionTimeout>' : '' ) +
 				'</Configuration>' +
-				'<ForcePersistence>true</ForcePersistence>' +
+				(!this.media2Support?'<ForcePersistence>true</ForcePersistence>':'') +
 			'</SetVideoEncoderConfiguration>' +
 			this._envelopeFooter()
 		}, function(err, data, xml) {
@@ -450,7 +457,10 @@ module.exports = function(Cam) {
 					: err, data, xml);
 			}
 			//get new encoding settings from device
-			this.getVideoEncoderConfiguration(options.token || options.$.token, callback);
+			if(!this.media2Support)
+				this.getVideoEncoderConfiguration(options.token || options.$.token, callback);
+			else
+				this.getVideoEncoderConfigurations( callback);
 		}.bind(this));
 	};
 

--- a/lib/media.js
+++ b/lib/media.js
@@ -305,9 +305,9 @@ module.exports = function(Cam) {
 			return callback(new Error("'options' must have one or both 'configurationToken' or 'profileToken'"));
 		}
 		const service = this.media2Support ? 'media2' : 'media';
-		const xmlns = this.media2Support? 'http://www.onvif.org/ver20/media/wsdl': 'http://www.onvif.org/ver10/media/wsdl';
+		const xmlns = this.media2Support ? 'http://www.onvif.org/ver20/media/wsdl' : 'http://www.onvif.org/ver10/media/wsdl';
 		this._request({
-			service: 'media'
+			service: service
 			, body: this._envelopeHeader() +
 			(
 				(options) ?
@@ -342,7 +342,7 @@ module.exports = function(Cam) {
 	Cam.prototype.getVideoEncoderConfigurations = function(callback) {
 
 		const service = this.media2Support ? 'media2' : 'media';
-		const xmlns = this.media2Support? 'http://www.onvif.org/ver20/media/wsdl': 'http://www.onvif.org/ver10/media/wsdl';
+		const xmlns = this.media2Support ? 'http://www.onvif.org/ver20/media/wsdl' : 'http://www.onvif.org/ver10/media/wsdl';
 		this._request({
 			service: service
 			, body: this._envelopeHeader() +
@@ -398,12 +398,13 @@ module.exports = function(Cam) {
 			return callback(new Error('No video encoder configuration token is present!'));
 		}
 		const service = this.media2Support ? 'media2' : 'media';
-		const xmlns = this.media2Support? 'http://www.onvif.org/ver20/media/wsdl': 'http://www.onvif.org/ver10/media/wsdl';
+		const xmlns = this.media2Support ? 'http://www.onvif.org/ver20/media/wsdl' : 'http://www.onvif.org/ver10/media/wsdl';
+		const ConstantBitRate = (options.rateControl && options.rateControl.$ && options.rateControl.$.ConstantBitRate) || false;
 		this._request({
 			service: service,
 			body: this._envelopeHeader() +
-			`<SetVideoEncoderConfiguration xmlns="${xmlns}">`+
-				`<Configuration token="${options.token ?? options.$.token}"` + (options.$.GovLength?` GovLength="${options.$.GovLength}"`:'')  + (options.$.Profile?` Profile="${options.$.Profile}"`:'')  +'>' +
+			`<SetVideoEncoderConfiguration xmlns="${xmlns}">` +
+				`<Configuration token="${options.token || options.$.token}"` + (options.$.GovLength ? ` GovLength="${options.$.GovLength}"` : '')  + (options.$.Profile ? ` Profile="${options.$.Profile}"` : '')  + '>' +
 				( options.name ? '<Name xmlns="http://www.onvif.org/ver10/schema">' + options.name + '</Name>' : '' ) +
 				( options.useCount ? '<UseCount xmlns="http://www.onvif.org/ver10/schema">' + options.useCount + '</UseCount>' : '' ) +
 				( options.encoding ? '<Encoding xmlns="http://www.onvif.org/ver10/schema">' + options.encoding + '</Encoding>' : '' ) +
@@ -414,7 +415,7 @@ module.exports = function(Cam) {
 				'</Resolution>' : '') +
 				( options.quality ? '<Quality xmlns="http://www.onvif.org/ver10/schema">' + options.quality + '</Quality>' : '' ) +
 				( options.rateControl ?
-					`<RateControl ConstantBitRate="${options.rateControl.$?.ConstantBitRate}"  xmlns="http://www.onvif.org/ver10/schema"> ` +
+					`<RateControl ConstantBitRate="${ConstantBitRate}"  xmlns="http://www.onvif.org/ver10/schema"> ` +
 					( options.rateControl.frameRateLimit ? '<FrameRateLimit>' + options.rateControl.frameRateLimit + '</FrameRateLimit>' : '' ) +
 					( options.rateControl.encodingInterval ? '<EncodingInterval>' + options.rateControl.encodingInterval + '</EncodingInterval>' : '' ) +
 					( options.rateControl.bitrateLimit ? '<BitrateLimit>' + options.rateControl.bitrateLimit + '</BitrateLimit>' : '' ) +
@@ -447,7 +448,7 @@ module.exports = function(Cam) {
 					options.sessionTimeout +
 				'</SessionTimeout>' : '' ) +
 				'</Configuration>' +
-				(!this.media2Support?'<ForcePersistence>true</ForcePersistence>':'') +
+				(!this.media2Support ? '<ForcePersistence>true</ForcePersistence>' : '') +
 			'</SetVideoEncoderConfiguration>' +
 			this._envelopeFooter()
 		}, function(err, data, xml) {
@@ -457,10 +458,7 @@ module.exports = function(Cam) {
 					: err, data, xml);
 			}
 			//get new encoding settings from device
-			if(!this.media2Support)
-				this.getVideoEncoderConfiguration(options.token || options.$.token, callback);
-			else
-				this.getVideoEncoderConfigurations( callback);
+			if (!this.media2Support) {this.getVideoEncoderConfiguration(options.token || options.$.token, callback);} else {this.getVideoEncoderConfigurations( callback);}
 		}.bind(this));
 	};
 

--- a/lib/media.js
+++ b/lib/media.js
@@ -400,11 +400,13 @@ module.exports = function(Cam) {
 		const service = this.media2Support ? 'media2' : 'media';
 		const xmlns = this.media2Support ? 'http://www.onvif.org/ver20/media/wsdl' : 'http://www.onvif.org/ver10/media/wsdl';
 		const ConstantBitRate = (options.rateControl && options.rateControl.$ && options.rateControl.$.ConstantBitRate) || false;
+		const media2GovLength = (options.$ && options.$.GovLength) || undefined;
+		const media2Profile = (options.$ && options.$.Profile) || undefined; 
 		this._request({
 			service: service,
 			body: this._envelopeHeader() +
 			`<SetVideoEncoderConfiguration xmlns="${xmlns}">` +
-				`<Configuration token="${options.token || options.$.token}"` + (options.$.GovLength ? ` GovLength="${options.$.GovLength}"` : '')  + (options.$.Profile ? ` Profile="${options.$.Profile}"` : '')  + '>' +
+				`<Configuration token="${options.token || options.$.token}"` + (media2GovLength ? ` GovLength="${media2GovLength}"` : '')  + (media2Profile ? ` Profile="${media2Profile}"` : '')  + '>' +
 				( options.name ? '<Name xmlns="http://www.onvif.org/ver10/schema">' + options.name + '</Name>' : '' ) +
 				( options.useCount ? '<UseCount xmlns="http://www.onvif.org/ver10/schema">' + options.useCount + '</UseCount>' : '' ) +
 				( options.encoding ? '<Encoding xmlns="http://www.onvif.org/ver10/schema">' + options.encoding + '</Encoding>' : '' ) +


### PR DESCRIPTION
Added Media2 support for the following functions:

GetVideoEncoderConfigurations and GetVideoEncoderConfigurationOptions
SetVideoEncoderConfiguration
With these updates, we now support setting the H.265 encoder and configuring constant bit rate.

Sources:

[ONVIF Media2 WSDL](https://www.onvif.org/ver20/media/wsdl/media.wsdl)
Tested on Hanwha camera.