### PR TITLE
ci: add testing on node 22 and 24

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x,18.x,20.x]
+        node-version: [16.x,18.x,20.x, 22.x, 24.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This adds running the tests in PR for node versions 22 and 24