### PR TITLE
feat: move all methods for the connection to the separate module, not…

### DIFF
--- a/__tests__/compatibility.promises.unit.test.ts
+++ b/__tests__/compatibility.promises.unit.test.ts
@@ -121,45 +121,36 @@ describe('compatibility promises unit', () => {
       jest.restoreAllMocks();
     });
 
-    async function withConcreteServices(onvif: Onvif) {
-      const Media2 = (await import('../src/media2')).default;
-      const Media = (await import('../src/media')).default;
-      const media2 = new Media2(onvif);
-      const media = new Media(onvif);
-      Object.defineProperty(onvif, 'media2', { configurable: true, value: media2 });
-      Object.defineProperty(onvif, 'media', { configurable: true, value: media });
-      return { media2, media };
-    }
-
     it('disables media2Support when Media2 GetProfiles fails (D-Link workaround)', async () => {
+      const { connectSteps } = await import('../src/connection');
       const onvif = new Onvif({ hostname: '127.0.0.1', autoConnect: false });
-      const { media2, media } = await withConcreteServices(onvif);
-      onvif.device.media2Support = true;
+      onvif.media2Support = true;
       jest.spyOn(onvif, 'getSystemDateAndTime').mockResolvedValue(new Date() as never);
-      jest.spyOn(onvif.device, 'getServices').mockResolvedValue({ service: [] } as never);
-      jest.spyOn(media2, 'getProfiles').mockRejectedValue(new Error('media2 broken'));
-      jest.spyOn(media, 'getProfiles').mockResolvedValue([]);
-      jest.spyOn(media, 'getVideoSources').mockResolvedValue([]);
-      jest.spyOn(onvif, 'getActiveSources').mockResolvedValue(undefined as never);
+      jest.spyOn(connectSteps, 'getServices').mockResolvedValue({ service: [] } as never);
+      jest.spyOn(connectSteps, 'probeMedia2Profiles').mockRejectedValue(new Error('media2 broken'));
+      jest.spyOn(connectSteps, 'getMediaProfiles').mockResolvedValue([]);
+      jest.spyOn(connectSteps, 'getVideoSources').mockResolvedValue([]);
+      jest.spyOn(connectSteps, 'getActiveSources').mockResolvedValue(undefined as never);
 
       await onvif.connect();
-      expect(onvif.device.media2Support).toBe(false);
-      expect(media.getProfiles).toHaveBeenCalled();
+      expect(onvif.media2Support).toBe(false);
+      expect(connectSteps.getMediaProfiles).toHaveBeenCalled();
     });
 
     it('keeps media2Support when Media2 GetProfiles succeeds', async () => {
+      const { connectSteps } = await import('../src/connection');
       const onvif = new Onvif({ hostname: '127.0.0.1', autoConnect: false });
-      const { media2, media } = await withConcreteServices(onvif);
-      onvif.device.media2Support = true;
+      onvif.media2Support = true;
       jest.spyOn(onvif, 'getSystemDateAndTime').mockResolvedValue(new Date() as never);
-      jest.spyOn(onvif.device, 'getServices').mockResolvedValue({ service: [] } as never);
-      jest.spyOn(media2, 'getProfiles').mockResolvedValue([]);
-      jest.spyOn(media, 'getProfiles').mockResolvedValue([]);
-      jest.spyOn(media, 'getVideoSources').mockResolvedValue([]);
-      jest.spyOn(onvif, 'getActiveSources').mockResolvedValue(undefined as never);
+      jest.spyOn(connectSteps, 'getServices').mockResolvedValue({ service: [] } as never);
+      jest.spyOn(connectSteps, 'probeMedia2Profiles').mockResolvedValue(undefined);
+      jest.spyOn(connectSteps, 'getMediaProfiles').mockResolvedValue([]);
+      jest.spyOn(connectSteps, 'getVideoSources').mockResolvedValue([]);
+      jest.spyOn(connectSteps, 'getActiveSources').mockResolvedValue(undefined as never);
 
       await onvif.connect();
-      expect(onvif.device.media2Support).toBe(true);
+      expect(onvif.media2Support).toBe(true);
+      expect(connectSteps.probeMedia2Profiles).toHaveBeenCalled();
     });
   });
 

--- a/__tests__/media.test.ts
+++ b/__tests__/media.test.ts
@@ -61,7 +61,7 @@ describe('Profiles', () => {
     });
 
     it('should return media profiles ver10', async () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       try {
         const result = await cam.media.getProfiles();
         expect(result.length).toBeGreaterThan(0);
@@ -76,7 +76,7 @@ describe('Profiles', () => {
         expect(result[0]).toHaveProperty('PTZConfiguration');
         expect(result[0]).toHaveProperty('metadataConfiguration');
       } finally {
-        cam.device.media2Support = true;
+        cam.media2Support = true;
       }
     });
   });
@@ -104,12 +104,12 @@ describe('Profiles', () => {
     });
 
     it('should return the profile ver10 by its token', async () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       try {
         const result = await cam.media.getProfile({ profileToken: newProfileToken });
         expect(result.fixed).toBe(false);
       } finally {
-        cam.device.media2Support = true;
+        cam.media2Support = true;
       }
     });
   });
@@ -595,7 +595,7 @@ describe('getStreamUri', () => {
     it.each([['UDP'], ['RTSP'], ['HTTP'], ['TCP']] as const)(
       'should return a stream URI when protocol is %s',
       async (protocol) => {
-        cam.device.media2Support = false;
+        cam.media2Support = false;
         try {
           const result = await cam.media.getStreamUri({
             profileToken: 'ProfileToken_1',
@@ -608,7 +608,7 @@ describe('getStreamUri', () => {
           expect(typeof mediaUri.uri).toBe('string');
           expect(mediaUri.uri.length).toBeGreaterThan(0);
         } finally {
-          cam.device.media2Support = true;
+          cam.media2Support = true;
         }
       },
     );
@@ -644,7 +644,7 @@ describe('getSnapshotUri', () => {
 
   describe('Media ver10', () => {
     it('should return a snapshot media URI when Media2 is not supported', async () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       try {
         const result = await cam.media.getSnapshotUri({
           profileToken: 'ProfileToken_1',
@@ -653,7 +653,7 @@ describe('getSnapshotUri', () => {
         expect(typeof result.mediaUri!.uri).toBe('string');
         expect(result.mediaUri!.uri!.length).toBeGreaterThan(0);
       } finally {
-        cam.device.media2Support = true;
+        cam.media2Support = true;
       }
     });
   });

--- a/__tests__/media2.test.ts
+++ b/__tests__/media2.test.ts
@@ -113,9 +113,9 @@ describe('Profiles', () => {
     });
 
     it('should fail if media ver20 is not supported', async () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       expect(() => cam.media2.getProfiles()).toThrow();
-      cam.device.media2Support = true;
+      cam.media2Support = true;
     });
   });
 
@@ -898,13 +898,13 @@ describe('getStreamUri', () => {
   });
 
   it('should fail if media ver20 is not supported', () => {
-    cam.device.media2Support = false;
+    cam.media2Support = false;
     try {
       expect(() => cam.media2.getStreamUri({ protocol, profileToken: cam.activeSource!.profileToken })).toThrow(
         'Media2 profile is not supported for this device',
       );
     } finally {
-      cam.device.media2Support = true;
+      cam.media2Support = true;
     }
   });
 });
@@ -933,13 +933,13 @@ describe('getSnapshotUri', () => {
   });
 
   it('should fail if media ver20 is not supported', () => {
-    cam.device.media2Support = false;
+    cam.media2Support = false;
     try {
       expect(() => cam.media2.getSnapshotUri({ profileToken: cam.activeSource!.profileToken })).toThrow(
         'Media2 profile is not supported for this device',
       );
     } finally {
-      cam.device.media2Support = true;
+      cam.media2Support = true;
     }
   });
 });
@@ -972,11 +972,11 @@ describe('OSD', () => {
     });
 
     it('should fail if media ver20 is not supported', () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       try {
         expect(() => cam.media2.getOSDs()).toThrow('Media2 profile is not supported for this device');
       } finally {
-        cam.device.media2Support = true;
+        cam.media2Support = true;
       }
     });
   });
@@ -990,13 +990,13 @@ describe('OSD', () => {
     });
 
     it('should fail if media ver20 is not supported', () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       try {
         expect(() => cam.media2.getOSDOptions({ configurationToken: videoSourceConfigurationToken })).toThrow(
           'Media2 profile is not supported for this device',
         );
       } finally {
-        cam.device.media2Support = true;
+        cam.media2Support = true;
       }
     });
   });
@@ -1012,7 +1012,7 @@ describe('OSD', () => {
     });
 
     it('should fail if media ver20 is not supported', () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       try {
         expect(() =>
           cam.media2.setOSD({
@@ -1024,7 +1024,7 @@ describe('OSD', () => {
           }),
         ).toThrow('Media2 profile is not supported for this device');
       } finally {
-        cam.device.media2Support = true;
+        cam.media2Support = true;
       }
     });
   });
@@ -1053,7 +1053,7 @@ describe('OSD', () => {
     });
 
     it('should fail createOSD if media ver20 is not supported', () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       try {
         expect(() =>
           cam.media2.createOSD({
@@ -1065,18 +1065,18 @@ describe('OSD', () => {
           }),
         ).toThrow('Media2 profile is not supported for this device');
       } finally {
-        cam.device.media2Support = true;
+        cam.media2Support = true;
       }
     });
 
     it('should fail deleteOSD if media ver20 is not supported', () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       try {
         expect(() => cam.media2.deleteOSD({ OSDToken: 'x' })).toThrow(
           'Media2 profile is not supported for this device',
         );
       } finally {
-        cam.device.media2Support = true;
+        cam.media2Support = true;
       }
     });
   });
@@ -1100,11 +1100,11 @@ describe('getServiceCapabilities', () => {
   });
 
   it('should fail if media ver20 is not supported', () => {
-    cam.device.media2Support = false;
+    cam.media2Support = false;
     try {
       expect(() => cam.media2.getServiceCapabilities()).toThrow('Media2 profile is not supported for this device');
     } finally {
-      cam.device.media2Support = true;
+      cam.media2Support = true;
     }
   });
 });
@@ -1144,11 +1144,11 @@ describe('Masks', () => {
     });
 
     it('should fail if media ver20 is not supported', () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       try {
         expect(() => cam.media2.getMasks()).toThrow('Media2 profile is not supported for this device');
       } finally {
-        cam.device.media2Support = true;
+        cam.media2Support = true;
       }
     });
   });
@@ -1171,13 +1171,13 @@ describe('Masks', () => {
     });
 
     it('should fail if media ver20 is not supported', () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       try {
         expect(() => cam.media2.getMaskOptions({ configurationToken: videoSourceConfigurationToken })).toThrow(
           'Media2 profile is not supported for this device',
         );
       } finally {
-        cam.device.media2Support = true;
+        cam.media2Support = true;
       }
     });
   });
@@ -1300,11 +1300,11 @@ describe('Masks', () => {
     });
 
     it('should fail deleteMask if media ver20 is not supported', () => {
-      cam.device.media2Support = false;
+      cam.media2Support = false;
       try {
         expect(() => cam.media2.deleteMask({ token: 'x' })).toThrow('Media2 profile is not supported for this device');
       } finally {
-        cam.device.media2Support = true;
+        cam.media2Support = true;
       }
     });
   });

--- a/__tests__/onvif.test.ts
+++ b/__tests__/onvif.test.ts
@@ -11,6 +11,8 @@ describe('Common', () => {
   it('should connect to the cam, fill startup properties', () => {
     expect(cam.uri.PTZ?.href).toBeDefined();
     expect(cam.uri.media).toBeDefined();
+    expect(cam.videoSources).toBeDefined();
+    expect(cam.profiles).toBeDefined();
     expect(cam.media.videoSources).toBeDefined();
     expect(cam.media.profiles).toBeDefined();
     expect(cam.defaultProfile).toBeDefined();

--- a/__tests__/unit.mocked.services.test.ts
+++ b/__tests__/unit.mocked.services.test.ts
@@ -982,7 +982,7 @@ describe('Mocked service unit tests', () => {
 
   it('exercises AdvancedSecurity, Analytics, Media2, DeviceIO, and Cam helpers', async () => {
     const onvif = new Onvif({ hostname: '127.0.0.1', autoConnect: false });
-    onvif.device.media2Support = true;
+    onvif.media2Support = true;
 
     const security = new AdvancedSecurity(onvif);
     mockServiceRequest(security, (body) => {

--- a/__tests__/unit.optional.payloads.test.ts
+++ b/__tests__/unit.optional.payloads.test.ts
@@ -496,7 +496,7 @@ describe('Optional payloads and empty responses', () => {
     await security.getAuthorizationServerConfigurations({ token: 'as1' } as any);
 
     const media = new Media(onvif);
-    onvif.device.media2Support = false;
+    onvif.media2Support = false;
     mockEmpty(media);
     await media.getOSDs({ configurationToken: 'vsc1', OSDToken: 'osd1' } as any);
     await media.setOSD({

--- a/__tests__/unit.options.builders.test.ts
+++ b/__tests__/unit.options.builders.test.ts
@@ -156,9 +156,10 @@ describe('Service options and builders', () => {
     expect((proxy as any).value).toBe(7);
 
     const unloaded = lazyService(onvif, async () => ({ default: Dummy }));
-    expect(() => {
-      (unloaded as any).value = 1;
-    }).toThrow(/before class is loaded/);
+    (unloaded as any).value = 1;
+    expect((unloaded as any).value).toBe(1);
+    expect(await (unloaded as any).ping()).toBe('pong');
+    expect((unloaded as any).value).toBe(1);
   });
 
   it('builds event filters and event broker configs with optional fields', async () => {
@@ -472,7 +473,7 @@ describe('Service options and builders', () => {
       videoSourceConfigurationToken: 'vsc1',
       profileToken: 'p1',
     } as any;
-    onvif.device.media2Support = false;
+    onvif.media2Support = false;
     const media = new Media(onvif);
     jest.spyOn(media as any, 'request').mockResolvedValue({
       createOSDResponse: { OSDToken: 'osd1' },

--- a/src/compatibility/cam.ts
+++ b/src/compatibility/cam.ts
@@ -274,7 +274,7 @@ export class Cam extends EventEmitter {
     this.onvif.xaddrs = value;
   }
   get services() {
-    return this.onvif.device.services;
+    return this.onvif.services;
   }
   get capabilities() {
     return this.onvif.capabilities;
@@ -283,10 +283,10 @@ export class Cam extends EventEmitter {
     return this.onvif.uri;
   }
   get videoSources() {
-    return this.onvif.media.videoSources;
+    return this.onvif.videoSources;
   }
   get profiles() {
-    return this.onvif.media.profiles;
+    return this.onvif.profiles;
   }
   get defaultProfile() {
     return this.onvif.defaultProfile;
@@ -320,7 +320,7 @@ export class Cam extends EventEmitter {
     return this.onvif.device.scopes;
   }
   get media2Support() {
-    return this.onvif.device.media2Support;
+    return this.onvif.media2Support;
   }
   get NTP() {
     return this.onvif.device.NTP;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,0 +1,250 @@
+/**
+ * Connection for {@link Onvif}.
+ * SOAP used by {@link connect} lives here so `device` / `media` / `media2` modules are not loaded.
+ */
+
+import type { Onvif, OnvifServices } from './onvif';
+import type { Capabilities, CapabilitiesExtension, Profile, VideoSource } from './interfaces/onvif';
+import type {
+  GetCapabilities,
+  GetServices,
+  GetServicesResponse,
+  Service as DeviceService,
+} from './interfaces/devicemgmt';
+import type { GetProfilesResponse } from './interfaces/media';
+import type { LineraseOptions } from './utils';
+import { XMLNS } from './service';
+
+/** Same array/rawXML hints as Media.getProfiles for linerase. */
+const MEDIA_PROFILE_PARSE: LineraseOptions = {
+  array: ['configurations', 'analyticsModule', 'rule', 'simpleItem', 'elementItem'],
+  rawXML: ['elementItem', 'subscriptionPolicy', 'filter'],
+};
+
+async function serviceRequest(
+  onvif: Onvif,
+  service: keyof OnvifServices,
+  body: Record<string, any>,
+  options?: LineraseOptions,
+) {
+  const root = Object.keys(body)[0];
+  body[root].$ = {
+    xmlns: XMLNS[service],
+    ...body[root].$,
+  };
+  const [data] = await onvif.request({
+    service,
+    body,
+    array: options?.array,
+    rawXML: options?.rawXML,
+  });
+  return data;
+}
+
+/**
+ * Returns information about services of the device (Device.GetServices).
+ */
+export async function getServices(
+  onvif: Onvif,
+  { includeCapability }: GetServices = { includeCapability: true },
+): Promise<GetServicesResponse> {
+  const response = await serviceRequest(onvif, 'device', {
+    GetServices: {
+      IncludeCapability: includeCapability,
+    },
+  });
+  const result = response.getServicesResponse as GetServicesResponse;
+  onvif.services = result.service ?? [];
+  // ONVIF Profile T introduced Media2 (ver20) so cameras from around 2020/2021 will have
+  // two media entries in the ServicesResponse, one for Media (ver10/media) and one for Media2 (ver20/media)
+  onvif.services.forEach((service: DeviceService) => {
+    if (
+      Object.prototype.hasOwnProperty.call(service, 'namespace') &&
+      Object.prototype.hasOwnProperty.call(service, 'XAddr')
+    ) {
+      if (!service.namespace || !service.XAddr) {
+        return;
+      }
+      const parsedNamespace = new URL(service.namespace);
+      if (parsedNamespace.hostname === 'www.onvif.org' && parsedNamespace.pathname) {
+        const namespaceSplitted = parsedNamespace.pathname.substring(1).split('/');
+        if (namespaceSplitted[1] === 'media' && namespaceSplitted[0] === 'ver20') {
+          onvif.media2Support = true;
+          namespaceSplitted[1] = 'media2';
+        } else if (namespaceSplitted[1] === 'ptz') {
+          namespaceSplitted[1] = 'PTZ';
+        }
+        onvif.uri[namespaceSplitted[1] as keyof OnvifServices] = onvif.parseUrl(service.XAddr);
+      }
+    }
+  });
+  return result;
+}
+
+/**
+ * Device.GetCapabilities (legacy fallback when GetServices is unavailable).
+ */
+export async function getCapabilities(onvif: Onvif, options?: GetCapabilities): Promise<Capabilities> {
+  if (!options || !options.category) {
+    options = { category: ['All'] };
+  }
+  const response = await serviceRequest(onvif, 'device', {
+    GetCapabilities: {
+      Category: options.category,
+    },
+  });
+  onvif.capabilities = response.getCapabilitiesResponse.capabilities as Capabilities;
+  ['PTZ', 'media', 'imaging', 'events', 'device', 'analytics'].forEach((name) => {
+    if (name in onvif.capabilities) {
+      const capabilityName = name as keyof Capabilities;
+      if ('XAddr' in onvif.capabilities[capabilityName]!) {
+        onvif.uri[name as keyof OnvifServices] = onvif.parseUrl(onvif.capabilities[capabilityName]!.XAddr as string);
+      }
+    }
+  });
+  if (onvif.capabilities.extension) {
+    Object.keys(onvif.capabilities.extension).forEach((ext) => {
+      const extensionName = ext as keyof CapabilitiesExtension;
+      if (
+        'XAddr' in onvif.capabilities.extension![extensionName]! &&
+        onvif.capabilities.extension![extensionName]!.XAddr
+      ) {
+        onvif.uri[extensionName] = new URL(onvif.capabilities.extension![extensionName]!.XAddr as string);
+      }
+    });
+    if (onvif.uri.replay && !onvif.uri.recording) {
+      const tempRecorderXaddr = onvif.uri.replay.href.replace('replay', 'recording');
+      onvif.emit('warn', new Error(`Adding ${tempRecorderXaddr} for bad Profile G device`));
+      onvif.uri.recording = new URL(tempRecorderXaddr);
+    }
+  }
+  return onvif.capabilities;
+}
+
+/**
+ * Media1 GetProfiles — stores result on {@link Onvif.profiles}.
+ */
+export async function getMediaProfiles(onvif: Onvif): Promise<Profile[]> {
+  const response = await serviceRequest(onvif, 'media', { GetProfiles: {} }, MEDIA_PROFILE_PARSE);
+  onvif.profiles = (response as { getProfilesResponse: GetProfilesResponse }).getProfilesResponse.profiles ?? [];
+  return onvif.profiles;
+}
+
+/**
+ * Media1 GetVideoSources — stores result on {@link Onvif.videoSources}.
+ */
+export async function getVideoSources(onvif: Onvif): Promise<VideoSource[]> {
+  const response = await serviceRequest(onvif, 'media', { GetVideoSources: {} }, { array: ['videoSources'] });
+  onvif.videoSources = response.getVideoSourcesResponse.videoSources;
+  return onvif.videoSources;
+}
+
+/** Probe Media2 GetProfiles (D-Link workaround); does not keep the result. */
+export async function probeMedia2Profiles(onvif: Onvif): Promise<void> {
+  await serviceRequest(
+    onvif,
+    'media2',
+    {
+      GetProfiles: {
+        Type: 'All',
+      },
+    },
+    { array: ['profiles'] },
+  );
+}
+
+/**
+ * Check and find out video configuration for device
+ */
+export async function getActiveSources(onvif: Onvif): Promise<void> {
+  if (!onvif.videoSources?.length) {
+    return;
+  }
+
+  onvif.videoSources.forEach(({ token: videoSrcToken }, idx) => {
+    let appropriateProfiles = onvif.profiles.filter(
+      (profile) =>
+        profile.videoSourceConfiguration?.sourceToken === videoSrcToken &&
+        profile.videoEncoderConfiguration !== undefined,
+    );
+
+    if (appropriateProfiles.length === 0) {
+      appropriateProfiles = onvif.profiles.filter((profile) => profile.videoEncoderConfiguration !== undefined);
+    }
+    if (appropriateProfiles.length === 0) {
+      appropriateProfiles = [...onvif.profiles];
+    }
+    if (appropriateProfiles.length === 0) {
+      if (idx === 0) {
+        onvif.emit('warn', new Error('Unrecognized configuration: no media profiles available for video sources'));
+      }
+      return;
+    }
+
+    if (idx === 0) {
+      [onvif.defaultProfile] = appropriateProfiles;
+    }
+
+    [onvif.defaultProfiles[idx]] = appropriateProfiles;
+
+    onvif.activeSources[idx] = {
+      sourceToken: videoSrcToken,
+      profileToken: onvif.defaultProfiles[idx].token,
+      videoSourceConfigurationToken: onvif.defaultProfiles[idx].videoSourceConfiguration?.token ?? videoSrcToken,
+      videoSourceToken: videoSrcToken,
+    };
+    if (onvif.defaultProfiles[idx].videoEncoderConfiguration) {
+      const configuration = onvif.defaultProfiles[idx].videoEncoderConfiguration;
+      onvif.activeSources[idx].encoding = configuration?.encoding;
+      onvif.activeSources[idx].width = configuration?.resolution?.width;
+      onvif.activeSources[idx].height = configuration?.resolution?.height;
+      onvif.activeSources[idx].fps = configuration?.rateControl?.frameRateLimit;
+      onvif.activeSources[idx].bitrate = configuration?.rateControl?.bitrateLimit;
+    }
+
+    if (idx === 0) {
+      onvif.activeSource = onvif.activeSources[idx];
+    }
+
+    if (onvif.defaultProfiles[idx].PTZConfiguration) {
+      onvif.activeSources[idx].ptz = {
+        name: onvif.defaultProfiles[idx].PTZConfiguration!.name as string,
+        token: onvif.defaultProfiles[idx].PTZConfiguration!.token,
+      };
+    }
+  });
+}
+
+/**
+ * Connect to the camera and fill device information properties
+ */
+export async function connect(onvif: Onvif): Promise<Onvif> {
+  await onvif.getSystemDateAndTime();
+  try {
+    await connectSteps.getServices(onvif);
+  } catch {
+    await connectSteps.getCapabilities(onvif);
+  }
+  // D-Link DCS-8635LH (and similar): GetServices advertises Media2 but Media2 GetProfiles fails.
+  if (onvif.media2Support) {
+    try {
+      await connectSteps.probeMedia2Profiles(onvif);
+    } catch {
+      onvif.media2Support = false;
+    }
+  }
+  await Promise.all([connectSteps.getMediaProfiles(onvif), connectSteps.getVideoSources(onvif)]);
+  await connectSteps.getActiveSources(onvif);
+  onvif.emit('connect');
+  return onvif;
+}
+
+/** Mutable step map so unit tests can spy without fighting CJS local bindings. */
+export const connectSteps = {
+  getServices,
+  getCapabilities,
+  getMediaProfiles,
+  getVideoSources,
+  probeMedia2Profiles,
+  getActiveSources,
+};

--- a/src/device.ts
+++ b/src/device.ts
@@ -3,7 +3,7 @@
  * @author Andrew D.Laptev <a.d.laptev@gmail.com>
  */
 
-import { Onvif, OnvifServices, SetSystemDateAndTimeExtended } from './onvif';
+import { Onvif, SetSystemDateAndTimeExtended } from './onvif';
 import Service from './service';
 import {
   AddIPAddressFilter,
@@ -83,7 +83,6 @@ import {
   BackupFile,
   BinaryData,
   Capabilities,
-  CapabilitiesExtension,
   Certificate,
   CertificateStatus,
   CertificateWithPrivateKey,
@@ -118,7 +117,6 @@ export default class Device extends Service {
   get services() {
     return this.#services;
   }
-  public media2Support = false;
   #scopes: Scope[] = [];
   get scopes() {
     return this.#scopes;
@@ -142,6 +140,7 @@ export default class Device extends Service {
 
   constructor(onvif: Onvif) {
     super(onvif, 'device');
+    this.#services = onvif.services;
   }
 
   private static namesToBuild(names?: string[]) {
@@ -372,42 +371,9 @@ export default class Device extends Service {
    * Returns information about services of the device.
    */
   async getServices({ includeCapability }: GetServices = { includeCapability: true }): Promise<GetServicesResponse> {
-    const response = await this.request({
-      GetServices: {
-        IncludeCapability: includeCapability,
-      },
-    });
-    const result = response.getServicesResponse;
-    this.#services = result.service;
-    // ONVIF Profile T introduced Media2 (ver20) so cameras from around 2020/2021 will have
-    // two media entries in the ServicesResponse, one for Media (ver10/media) and one for Media2 (ver20/media)
-    // This is so that existing VMS software can still access the video via the orignal ONVIF Media API
-    // fill Cam#uri property
-    this.#services.forEach((service) => {
-      // Look for services with namespaces and XAddr values
-      if (
-        Object.prototype.hasOwnProperty.call(service, 'namespace') &&
-        Object.prototype.hasOwnProperty.call(service, 'XAddr')
-      ) {
-        // Only parse ONVIF namespaces. Axis cameras return Axis namespaces in GetServices
-        if (!service.namespace || !service.XAddr) {
-          return;
-        }
-        const parsedNamespace = new URL(service.namespace);
-        if (parsedNamespace.hostname === 'www.onvif.org' && parsedNamespace.pathname) {
-          const namespaceSplitted = parsedNamespace.pathname.substring(1).split('/'); // remove leading Slash, then split
-          if (namespaceSplitted[1] === 'media' && namespaceSplitted[0] === 'ver20') {
-            // special case for Media and Media2 where cameras supporting Profile S and Profile T (2020/2021 models) have two media services
-            this.media2Support = true;
-            namespaceSplitted[1] = 'media2';
-          } else if (namespaceSplitted[1] === 'ptz') {
-            // uppercase PTZ namespace to fit names convention
-            namespaceSplitted[1] = 'PTZ';
-          }
-          this.onvif.uri[namespaceSplitted[1] as keyof OnvifServices] = this.onvif.parseUrl(service.XAddr);
-        }
-      }
-    });
+    const { getServices } = await import('./connection');
+    const result = await getServices(this.onvif, { includeCapability });
+    this.#services = this.onvif.services;
     return result;
   }
 
@@ -418,46 +384,8 @@ export default class Device extends Service {
    * @param options.category
    */
   async getCapabilities(options?: GetCapabilities): Promise<Capabilities> {
-    if (!options || !options.category) {
-      options = { category: ['All'] };
-    }
-    const response = await this.request({
-      GetCapabilities: {
-        Category: options.category,
-      },
-    });
-    this.onvif.capabilities = response.getCapabilitiesResponse.capabilities as Capabilities;
-    ['PTZ', 'media', 'imaging', 'events', 'device', 'analytics'].forEach((name) => {
-      // All names in GetCapabilities are optional in the WSL spec. For example, my Pelco IMP1110-1 does not support Analytics.
-      if (name in this.onvif.capabilities) {
-        const capabilityName = name as keyof Capabilities;
-        if ('XAddr' in this.onvif.capabilities[capabilityName]!) {
-          this.onvif.uri[name as keyof OnvifServices] = this.onvif.parseUrl(
-            this.onvif.capabilities[capabilityName]!.XAddr as string,
-          );
-        }
-      }
-    });
-    // extensions, eg. deviceIO
-    if (this.onvif.capabilities.extension) {
-      Object.keys(this.onvif.capabilities.extension).forEach((ext) => {
-        const extensionName = ext as keyof CapabilitiesExtension;
-        // TODO think about complex extensions like `telexCapabilities` and `scdlCapabilities`
-        if (
-          'XAddr' in this.onvif.capabilities.extension![extensionName]! &&
-          this.onvif.capabilities.extension![extensionName]!.XAddr
-        ) {
-          this.onvif.uri[extensionName] = new URL(this.onvif.capabilities.extension![extensionName]!.XAddr as string);
-        }
-      });
-      // HACK for a Profile G NVR that has 'replay' but did not have 'recording' in GetCapabilities
-      if (this.onvif.uri.replay && !this.onvif.uri.recording) {
-        const tempRecorderXaddr = this.onvif.uri.replay.href.replace('replay', 'recording');
-        this.onvif.emit('warn', new Error(`Adding ${tempRecorderXaddr} for bad Profile G device`));
-        this.onvif.uri.recording = new URL(tempRecorderXaddr);
-      }
-    }
-    return this.onvif.capabilities;
+    const { getCapabilities } = await import('./connection');
+    return getCapabilities(this.onvif, options);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,34 +1,37 @@
 export * from './onvif';
 export * from './events';
 export { default as Events } from './events';
-export { default as Device } from './device';
-export * from './media';
-export { default as Media } from './media';
-export * from './media2';
-export { default as Media2 } from './media2';
 export * from './discovery';
-export * from './ptz';
-export { default as PTZ } from './ptz';
-export * from './replay';
-export { default as Replay } from './replay';
-export { default as Imaging } from './imaging';
-export { default as Recording } from './recording';
-export { default as DoorControl } from './doorcontrol';
-export { default as AccessControl } from './accesscontrol';
-export { default as Credential } from './credential';
-export { default as AccessRules } from './accessrules';
-export { default as Schedule } from './schedule';
-export { default as Provisioning } from './provisioning';
-export { default as AdvancedSecurity } from './advancedsecurity';
-export { default as Thermal } from './thermal';
-export { default as Analytics } from './analytics';
-export { default as DeviceIO } from './deviceio';
-export { default as Display } from './display';
-export { default as ActionEngine } from './actionengine';
-export { default as Search } from './search';
-export { default as AnalyticsDevice } from './analyticsdevice';
-export { default as Receiver } from './receiver';
-export { default as Service } from './service';
 export * from './utils';
 export { xsany } from './utils/toOnvifXMLSchemaObject';
+
+// Service classes are type-only here so CommonJS `require('onvif')` does not load them.
+// Runtime instances come from lazy getters on Onvif (e.g. onvif.recording).
+export type { default as Device } from './device';
+export type { default as Media, GetStreamUriOptions } from './media';
+export type {
+  default as Media2,
+  ConfigurationRefExtended,
+  AudioOutputConfigurationExtended,
+} from './media2';
+export type { default as PTZ, GetPresetsExtended } from './ptz';
+export type { default as Replay, GetReplayUriOptions } from './replay';
+export type { default as Imaging } from './imaging';
+export type { default as Recording } from './recording';
+export type { default as DoorControl } from './doorcontrol';
+export type { default as AccessControl } from './accesscontrol';
+export type { default as Credential } from './credential';
+export type { default as AccessRules } from './accessrules';
+export type { default as Schedule } from './schedule';
+export type { default as Provisioning } from './provisioning';
+export type { default as AdvancedSecurity } from './advancedsecurity';
+export type { default as Thermal } from './thermal';
+export type { default as Analytics } from './analytics';
+export type { default as DeviceIO } from './deviceio';
+export type { default as Display } from './display';
+export type { default as ActionEngine } from './actionengine';
+export type { default as Search } from './search';
+export type { default as AnalyticsDevice } from './analyticsdevice';
+export type { default as Receiver } from './receiver';
+export type { default as Service } from './service';
 // export * from './compatibility/cam'; // use compatibility directly, ex.: require('onvif/compatibility/promises')

--- a/src/media.ts
+++ b/src/media.ts
@@ -99,7 +99,6 @@ import {
   GetOSD,
   GetVideoSourceConfigurationOptions,
   CreateOSDResponse,
-  GetProfilesResponse,
 } from './interfaces/media';
 import { DeleteOSD, GetOSDOptions, GetOSDOptionsResponse, GetOSDs, TransportProtocol } from './interfaces/media.2';
 import { config, multicastConfiguration, streamSetupToBuild, xsany } from './utils/toOnvifXMLSchemaObject';
@@ -192,6 +191,8 @@ export default class Media extends Service {
 
   constructor(onvif: Onvif) {
     super(onvif, 'media');
+    this.profiles = onvif.profiles;
+    this.videoSources = onvif.videoSources;
   }
 
   /**
@@ -211,12 +212,8 @@ export default class Media extends Service {
    * a device. The client does not need to know the media profile in order to use the command.
    */
   async getProfiles(): Promise<Profile[]> {
-    // Original ONVIF Media support (used in Profile S)
-    const response = await this.request<{ getProfilesResponse: GetProfilesResponse }>(
-      { GetProfiles: {} },
-      ConfigurationArraysAndExtensions,
-    );
-    this.profiles = response.getProfilesResponse.profiles ?? [];
+    const { getMediaProfiles } = await import('./connection');
+    this.profiles = await getMediaProfiles(this.onvif);
     return this.profiles;
   }
 
@@ -538,8 +535,8 @@ export default class Media extends Service {
    * video sources through the GetVideoSources command
    */
   async getVideoSources(): Promise<VideoSource[]> {
-    const response = await this.request({ GetVideoSources: {} }, { array: ['videoSources'] });
-    this.videoSources = response.getVideoSourcesResponse.videoSources;
+    const { getVideoSources } = await import('./connection');
+    this.videoSources = await getVideoSources(this.onvif);
     return this.videoSources;
   }
 
@@ -1479,7 +1476,7 @@ export default class Media extends Service {
   async getStreamUri(options: GetStreamUriOptions = {}): Promise<GetStreamUriResponse> {
     const { profileToken, stream = 'RTP-Unicast' } = options;
     const { protocol = 'RTSP' } = options;
-    if (this.onvif.device.media2Support) {
+    if (this.onvif.media2Support) {
       // Permitted values for options.protocol are :-
       //   RtspUnicast - RTSP streaming RTP via UDP Unicast.
       //   RtspMulticast - RTSP streaming RTP via UDP Multicast.
@@ -1535,7 +1532,7 @@ export default class Media extends Service {
       profileToken: this.onvif.activeSource!.profileToken,
     },
   ): Promise<GetSnapshotUriResponse> {
-    if (this.onvif.device.media2Support) {
+    if (this.onvif.media2Support) {
       // Profile T request using Media2
       const data = await this.onvif.media2.getSnapshotUri({ profileToken });
       return {
@@ -1640,7 +1637,7 @@ export default class Media extends Service {
    * @param OSDToken
    */
   async getOSDs({ configurationToken, OSDToken }: GetOSDs = {}): Promise<OSDConfiguration[]> {
-    if (this.onvif.device.media2Support) {
+    if (this.onvif.media2Support) {
       return this.onvif.media2.getOSDs({ configurationToken, OSDToken });
     }
     const response = await this.request(
@@ -1789,7 +1786,7 @@ export default class Media extends Service {
 
   async getOSDOptions(options?: GetOSDOptions): Promise<GetOSDOptionsResponse> {
     const configurationToken = options?.configurationToken ?? this.onvif.activeSource!.videoSourceConfigurationToken;
-    if (this.onvif.device.media2Support) {
+    if (this.onvif.media2Support) {
       const osdOptions = await this.onvif.media2.getOSDOptions({ configurationToken });
       return { OSDOptions: osdOptions };
     }
@@ -1804,7 +1801,7 @@ export default class Media extends Service {
 
 // function v1(originalMethod: any, context: ClassMethodDecoratorContext) {
 //   return function v1(this: any, ...args: any[]) {
-//     if (this.onvif.device.media2Support) {
+//     if (this.onvif.media2Support) {
 //       this.onvif.emit('warn', `Media2 profile has support for this device, you can try to use similar to \`${
 //         String(context.name)
 //       }' method from \`Media2 class\``);

--- a/src/media2.ts
+++ b/src/media2.ts
@@ -1226,7 +1226,7 @@ function v2(originalMethod: any, context: ClassMethodDecoratorContext) {
       throw new Error(`Media2.${String(context.name)} is not available on this instance`);
     }
     void context.access.get(this);
-    if (!this.onvif.device.media2Support) {
+    if (!this.onvif.media2Support) {
       throw new Error('Media2 profile is not supported for this device');
     }
     return originalMethod.call(this, ...args);

--- a/src/onvif.ts
+++ b/src/onvif.ts
@@ -11,14 +11,18 @@ import http, { Agent as HttpAgent } from 'http';
 import { Buffer } from 'buffer';
 import crypto from 'crypto';
 import { build, getDigestHeaders, linerase, OnvifResponse, parseSOAPString, splitArgs } from './utils';
-import Device from './device';
+import type Device from './device';
 import type Media from './media';
 import type Media2 from './media2';
 import type PTZ from './ptz';
-import { Capabilities, Profile, SystemDateTime } from './interfaces/onvif';
-import { GetDeviceInformationResponse, SetSystemDateAndTime } from './interfaces/devicemgmt';
-import { ReferenceToken } from './interfaces/common';
-import Events, { NotificationMessage } from './events';
+import type { Capabilities, Profile, SystemDateTime, VideoSource } from './interfaces/onvif';
+import type {
+  GetDeviceInformationResponse,
+  SetSystemDateAndTime,
+  Service as DeviceService,
+} from './interfaces/devicemgmt';
+import type { ReferenceToken } from './interfaces/common';
+import Events, { type NotificationMessage } from './events';
 import type Replay from './replay';
 import type Imaging from './imaging';
 import type Recording from './recording';
@@ -509,11 +513,19 @@ export class Onvif extends EventEmitter<OnvifEvents> {
   /** Clock offset between the device and this host (ms), set during time sync. */
   public timeShift?: number;
   public capabilities: Capabilities;
+  /** Filled by {@link connect} Device.getServices without loading the full Device module. */
+  public services: DeviceService[] = [];
+  /** Media1 profiles filled during connect (also copied onto Media when that module loads). */
+  public profiles: Profile[] = [];
+  /** Media1 video sources filled during connect. */
+  public videoSources: VideoSource[] = [];
   public defaultProfiles: Profile[] = [];
   public defaultProfile?: Profile;
   public activeSources: ActiveSource[] = [];
   public activeSource?: ActiveSource;
   public readonly urn?: string;
+  /** Set during connect when the device advertises ONVIF Media2 (Profile T). */
+  public media2Support = false;
   public deviceInformation?: GetDeviceInformationResponse;
   /** All XAddrs from WS-Discovery when this instance was found via {@link Discovery}. */
   public xaddrs?: URL[];
@@ -544,8 +556,8 @@ export class Onvif extends EventEmitter<OnvifEvents> {
     this.uri = {};
     this.capabilities = {};
 
-    this.device = new Device(this); // mandatory module for startup
-    this.media = lazyService<Media>(this, () => import('./media')); // mandatory? TODO think about connect() method
+    this.device = lazyService<Device>(this, () => import('./device'));
+    this.media = lazyService<Media>(this, () => import('./media'));
     this.media2 = lazyService<Media2>(this, () => import('./media2'));
     this.ptz = lazyService<PTZ>(this, () => import('./ptz'));
     this.events = new Events(this); // mandatory module for events
@@ -1065,95 +1077,15 @@ export class Onvif extends EventEmitter<OnvifEvents> {
    * Check and find out video configuration for device
    */
   public async getActiveSources() {
-    if (!this.media.videoSources?.length) {
-      return;
-    }
-
-    this.media.videoSources.forEach(({ token: videoSrcToken }, idx) => {
-      // let's choose first appropriate profile for our video source and make it default
-      let appropriateProfiles = this.media.profiles.filter(
-        (profile) =>
-          profile.videoSourceConfiguration?.sourceToken === videoSrcToken &&
-          profile.videoEncoderConfiguration !== undefined,
-      );
-
-      // Happytime and some devices return profiles without VideoSourceConfiguration.
-      // Fall back to any profile that has an encoder, then to any profile at all.
-      if (appropriateProfiles.length === 0) {
-        appropriateProfiles = this.media.profiles.filter((profile) => profile.videoEncoderConfiguration !== undefined);
-      }
-      if (appropriateProfiles.length === 0) {
-        appropriateProfiles = [...this.media.profiles];
-      }
-      if (appropriateProfiles.length === 0) {
-        if (idx === 0) {
-          this.emit(Onvif.WARN, new Error('Unrecognized configuration: no media profiles available for video sources'));
-        }
-        return;
-      }
-
-      if (idx === 0) {
-        [this.defaultProfile] = appropriateProfiles;
-      }
-
-      [this.defaultProfiles[idx]] = appropriateProfiles;
-
-      this.activeSources[idx] = {
-        sourceToken: videoSrcToken,
-        profileToken: this.defaultProfiles[idx].token,
-        videoSourceConfigurationToken: this.defaultProfiles[idx].videoSourceConfiguration?.token ?? videoSrcToken,
-        videoSourceToken: videoSrcToken,
-      };
-      if (this.defaultProfiles[idx].videoEncoderConfiguration) {
-        const configuration = this.defaultProfiles[idx].videoEncoderConfiguration;
-        this.activeSources[idx].encoding = configuration?.encoding;
-        this.activeSources[idx].width = configuration?.resolution?.width;
-        this.activeSources[idx].height = configuration?.resolution?.height;
-        this.activeSources[idx].fps = configuration?.rateControl?.frameRateLimit;
-        this.activeSources[idx].bitrate = configuration?.rateControl?.bitrateLimit;
-      }
-
-      if (idx === 0) {
-        this.activeSource = this.activeSources[idx];
-      }
-
-      if (this.defaultProfiles[idx].PTZConfiguration) {
-        this.activeSources[idx].ptz = {
-          name: this.defaultProfiles[idx].PTZConfiguration!.name as string,
-          token: this.defaultProfiles[idx].PTZConfiguration!.token,
-        };
-        /*
-        TODO Think about it
-        if (idx === 0) {
-          this.defaultProfile.PTZConfiguration = this.activeSources[idx].PTZConfiguration;
-        } */
-      }
-    });
+    const { getActiveSources } = await import('./connection');
+    return getActiveSources(this);
   }
 
   /**
    * Connect to the camera and fill device information properties
    */
   async connect() {
-    await this.getSystemDateAndTime();
-    // Try to get services (new approach). If not, get capabilities
-    try {
-      await this.device.getServices();
-    } catch (error) {
-      await this.device.getCapabilities();
-    }
-    // D-Link DCS-8635LH (and similar): GetServices advertises Media2 but Media2 GetProfiles fails.
-    // Probe once and fall back to Media1 for subsequent Media2-routed calls (stream URI, etc.).
-    if (this.device.media2Support) {
-      try {
-        await this.media2.getProfiles();
-      } catch {
-        this.device.media2Support = false;
-      }
-    }
-    await Promise.all([this.media.getProfiles(), this.media.getVideoSources()]);
-    await this.getActiveSources();
-    this.emit('connect');
-    return this;
+    const { connect } = await import('./connection');
+    return connect(this);
   }
 }

--- a/src/service.ts
+++ b/src/service.ts
@@ -7,7 +7,7 @@
 import { Onvif, OnvifServices } from './onvif';
 import { linerase, LineraseOptions } from './utils';
 
-const XMLNS: Record<keyof OnvifServices, string> = {
+export const XMLNS: Record<keyof OnvifServices, string> = {
   ptz: 'http://www.onvif.org/ver20/ptz/wsdl',
   analytics: 'http://www.onvif.org/ver20/analytics/wsdl',
   device: 'http://www.onvif.org/ver10/device/wsdl',
@@ -69,6 +69,7 @@ export function lazyService<T extends object>(
 ): T {
   let instance: T | undefined;
   let loading: Promise<T> | undefined;
+  const overrides = new Map<string | symbol, unknown>();
 
   const load = (): Promise<T> => {
     if (instance) {
@@ -77,6 +78,9 @@ export function lazyService<T extends object>(
 
     return (loading ??= loader().then(({ default: Service }) => {
       instance = new Service(onvif);
+      for (const [property, value] of overrides) {
+        Reflect.set(instance, property, value, instance);
+      }
       return instance;
     }));
   };
@@ -96,9 +100,16 @@ export function lazyService<T extends object>(
     {},
     {
       get(_target, property) {
+        if (overrides.has(property)) {
+          return overrides.get(property);
+        }
         if (instance) {
           const value = Reflect.get(instance, property, instance);
           if (typeof value === 'function') {
+            // Own props (e.g. jest.spyOn mocks) must be returned as-is for mock APIs.
+            if (Object.prototype.hasOwnProperty.call(instance, property)) {
+              return value;
+            }
             return (...args: unknown[]) => Reflect.apply(value, instance!, args);
           }
           return value;
@@ -106,12 +117,17 @@ export function lazyService<T extends object>(
         return (...args: unknown[]) => load().then((service) => resolveProperty(service, property, args));
       },
       set(_target, property, value) {
-        if (!instance) {
-          throw new Error(`Cannot set ${String(property)} before class is loaded`);
+        if (instance) {
+          overrides.delete(property);
+          return Reflect.set(instance, property, value, instance);
         }
-        return Reflect.set(instance, property, value, instance);
+        overrides.set(property, value);
+        return true;
       },
       has(_target, property) {
+        if (overrides.has(property)) {
+          return true;
+        }
         if (instance) {
           return Reflect.has(instance, property);
         }


### PR DESCRIPTION
… to load the whole device and media modules at the startup