### PR TITLE
fix: xml failures from some cameras

### DIFF
--- a/__tests__/api.regression.test.ts
+++ b/__tests__/api.regression.test.ts
@@ -26,6 +26,8 @@ const MAIN_RUNTIME_EXPORTS = [
   'guid',
   'linerase',
   'parseSOAPString',
+  'soapActionFromBody',
+  'soapActionFromXml',
   'splitArgs',
   'struct',
   'toIsoDuration',

--- a/__tests__/ws-security.test.ts
+++ b/__tests__/ws-security.test.ts
@@ -1,0 +1,205 @@
+/**
+ * WS-Security / SOAP request shape for #497 (Pelco empty body / Content-Type action).
+ * @jest-environment node
+ */
+
+import http from 'http';
+import { AddressInfo } from 'net';
+import { Onvif } from '../src';
+import { build, parseSOAPString, soapActionFromBody, soapActionFromXml } from '../src/utils';
+
+const ENCODING_TYPE =
+  'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary';
+const PASSWORD_TYPE =
+  'http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-username-token-profile-1.0#PasswordDigest';
+const DEVICE_NS = 'http://www.onvif.org/ver10/device/wsdl';
+
+const NONCE_RE = new RegExp(
+  `<Nonce EncodingType="${ENCODING_TYPE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}">([A-Za-z0-9+/=]+)</Nonce>`,
+);
+const PASSWORD_RE = new RegExp(
+  `<Password Type="${PASSWORD_TYPE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}">([A-Za-z0-9+/=]+)</Password>`,
+);
+
+describe('WS-Security UsernameToken XML', () => {
+  it('closes EncodingType and Type attribute quotes before Nonce/Password text', () => {
+    const xml = build({
+      Nonce: {
+        $: { EncodingType: ENCODING_TYPE },
+        _: '7Twd4BxrSFi2o1mvS8gmQ==',
+      },
+      Password: {
+        $: { Type: PASSWORD_TYPE },
+        _: 'd28eRQL+mEB4mDUwl22Xnt6eRRM=',
+      },
+    });
+
+    expect(xml).toMatch(NONCE_RE);
+    expect(xml).toMatch(PASSWORD_RE);
+    expect(xml).not.toMatch(/EncodingType="[^"]*Base64Binary[A-Za-z0-9+/=]+</);
+    expect(xml).not.toMatch(/Type="[^"]*PasswordDigest[A-Za-z0-9+/=]+</);
+  });
+
+  it('emits compact SOAP (no pretty-print) with well-formed Nonce/Password', async () => {
+    const onvif = new Onvif({
+      hostname: '127.0.0.1',
+      username: 'onvif',
+      password: 'secret',
+      autoConnect: false,
+      useWSSecurity: true,
+    });
+
+    let soap = '';
+    onvif.on('requestBody', (body) => {
+      soap = body;
+    });
+    jest.spyOn(onvif as any, 'rawRequest').mockResolvedValue([{}, '<ok/>']);
+
+    await onvif.request({
+      body: {
+        GetServices: {
+          $: { xmlns: DEVICE_NS },
+          IncludeCapability: true,
+        },
+      },
+    });
+
+    expect(soap).not.toMatch(/\n\s+<UsernameToken>/);
+    expect(soap).toContain('<UsernameToken>');
+    expect(soap).toMatch(NONCE_RE);
+    expect(soap).toMatch(PASSWORD_RE);
+    expect(soap).toContain(`EncodingType="${ENCODING_TYPE}">`);
+    expect(soap).toContain(`Type="${PASSWORD_TYPE}">`);
+  });
+
+  it('omits Security header when useWSSecurity is false', async () => {
+    const onvif = new Onvif({
+      hostname: '127.0.0.1',
+      username: 'onvif',
+      password: 'secret',
+      autoConnect: false,
+      useWSSecurity: false,
+    });
+
+    let soap = '';
+    onvif.on('requestBody', (body) => {
+      soap = body;
+    });
+    jest.spyOn(onvif as any, 'rawRequest').mockResolvedValue([{}, '<ok/>']);
+
+    await onvif.request({
+      body: {
+        GetServices: {
+          $: { xmlns: DEVICE_NS },
+          IncludeCapability: true,
+        },
+      },
+    });
+
+    expect(soap).not.toContain('<Security');
+    expect(soap).not.toContain('<Nonce');
+  });
+});
+
+describe('SOAP Content-Type action (#497 / v0 parity)', () => {
+  it('soapActionFromBody builds namespace/Operation', () => {
+    expect(
+      soapActionFromBody({
+        GetServices: { $: { xmlns: DEVICE_NS }, IncludeCapability: true },
+      }),
+    ).toBe(`${DEVICE_NS}/GetServices`);
+  });
+
+  it('soapActionFromXml reads operation xmlns from Body', () => {
+    const xml =
+      `<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">` +
+      `<s:Body>` +
+      `<GetSystemDateAndTime xmlns="${DEVICE_NS}"/>` +
+      `</s:Body></s:Envelope>`;
+    expect(soapActionFromXml(xml)).toBe(`${DEVICE_NS}/GetSystemDateAndTime`);
+  });
+
+  it('sends Content-Type with charset and SOAP action like v0.x', async () => {
+    let seenContentType = '';
+    const server = http.createServer((req, res) => {
+      seenContentType = String(req.headers['content-type'] ?? '');
+      res.writeHead(200, { 'Content-Type': 'application/soap+xml' });
+      res.end(
+        `<?xml version="1.0" encoding="UTF-8"?>` +
+          `<s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope">` +
+          `<s:Body><tds:GetServicesResponse xmlns:tds="${DEVICE_NS}"/></s:Body></s:Envelope>`,
+      );
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      const onvif = new Onvif({
+        hostname: '127.0.0.1',
+        port,
+        username: 'onvif',
+        password: 'secret',
+        autoConnect: false,
+        agent: false,
+      });
+      await onvif.request({
+        body: {
+          GetServices: {
+            $: { xmlns: DEVICE_NS },
+            IncludeCapability: true,
+          },
+        },
+      });
+      expect(seenContentType).toBe(
+        `application/soap+xml;charset=utf-8;action="${DEVICE_NS}/GetServices"`,
+      );
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+
+  it('rejects empty HTTP body with status code (Pelco-style #497)', async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/soap+xml' });
+      res.end('');
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as AddressInfo;
+
+    try {
+      const onvif = new Onvif({
+        hostname: '127.0.0.1',
+        port,
+        username: 'onvif',
+        password: 'secret',
+        autoConnect: false,
+        agent: false,
+      });
+      await expect(
+        onvif.request({
+          body: {
+            GetServices: {
+              $: { xmlns: DEVICE_NS },
+              IncludeCapability: true,
+            },
+          },
+        }),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining('Empty ONVIF SOAP response (HTTP 200)'),
+        xml: '',
+        statusCode: 200,
+      });
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((err) => (err ? reject(err) : resolve())));
+    }
+  });
+});
+
+describe('parseSOAPString empty / non-SOAP responses', () => {
+  it('rejects an empty response body', async () => {
+    await expect(parseSOAPString('')).rejects.toMatchObject({
+      message: expect.stringContaining('Empty ONVIF SOAP response'),
+      xml: '',
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onvif",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onvif",
-      "version": "1.0.0-rc.1",
+      "version": "1.0.0-rc.2",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^5.11.0"

--- a/src/onvif.ts
+++ b/src/onvif.ts
@@ -10,7 +10,7 @@ import https, { Agent as HttpsAgent, RequestOptions } from 'https';
 import http, { Agent as HttpAgent } from 'http';
 import { Buffer } from 'buffer';
 import crypto from 'crypto';
-import { build, getDigestHeaders, linerase, OnvifResponse, parseSOAPString, splitArgs } from './utils';
+import { build, getDigestHeaders, linerase, OnvifError, OnvifResponse, parseSOAPString, soapActionFromBody, soapActionFromXml, splitArgs } from './utils';
 import type Device from './device';
 import type Media from './media';
 import type Media2 from './media2';
@@ -41,7 +41,7 @@ import type ActionEngine from './actionengine';
 import type Search from './search';
 import type AnalyticsDevice from './analyticsdevice';
 import type Receiver from './receiver';
-import { lazyService } from './service';
+import { lazyService, XMLNS } from './service';
 
 /**
  * Cam constructor options
@@ -123,6 +123,11 @@ export interface OnvifRequestOptions extends Omit<RequestOptions, 'headers'> {
 export interface OnvifRawRequestOptions extends Omit<OnvifRequestOptions, 'body'> {
   /** SOAP body */
   body: string;
+  /**
+   * SOAP 1.2 action URI for Content-Type (namespace/Operation).
+   * When omitted, derived from the envelope Body like v0.x.
+   */
+  action?: string;
 }
 
 /**
@@ -696,7 +701,14 @@ export class Onvif extends EventEmitter<OnvifEvents> {
       };
       requestOptions.headers = {
         ...options.headers,
-        'Content-Type': 'application/soap+xml',
+        // Match v0.x: charset + SOAP action. Some devices (Pelco) reject requests without action
+        // and return an empty body (#497).
+        'Content-Type': (() => {
+          const action = options.action ?? soapActionFromXml(options.body);
+          return action
+            ? `application/soap+xml;charset=utf-8;action="${action}"`
+            : 'application/soap+xml;charset=utf-8';
+        })(),
         'Content-Length': Buffer.byteLength(options.body, 'utf8').toString(),
         charset: 'utf-8',
       };
@@ -741,6 +753,7 @@ export class Onvif extends EventEmitter<OnvifEvents> {
 
         const bufs: Buffer[] = [];
         let length = 0;
+        const statusCode = response.statusCode;
 
         response.on('data', (chunk) => {
           bufs.push(chunk);
@@ -754,6 +767,15 @@ export class Onvif extends EventEmitter<OnvifEvents> {
           alreadyReturned = true;
           const xml = Buffer.concat(bufs, length).toString('utf8');
           this.emit('rawResponse', xml);
+          if (!xml.trim()) {
+            reject(
+              new OnvifError(`Empty ONVIF SOAP response (HTTP ${statusCode ?? 'unknown'})`, {
+                xml,
+                statusCode,
+              }),
+            );
+            return;
+          }
           resolve(parseSOAPString(xml, options));
         });
         return undefined;
@@ -883,11 +905,14 @@ export class Onvif extends EventEmitter<OnvifEvents> {
       },
     };
     const body = build(bodyObject);
+    const fallbackXmlns = options.service ? XMLNS[options.service] : undefined;
+    const action = soapActionFromBody(options.body, fallbackXmlns);
 
     this.emit('requestBody', body);
     return this.rawRequest<Record<string, any>>({
       ...options,
       body,
+      action,
     }).then((result) => {
       this.lastResponseXml = result[1];
       return result;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,8 @@ interface OnvifErrorOptions {
    * Raw error response from the server
    */
   xml?: string;
+  /** HTTP status code when the failure came from an HTTP response */
+  statusCode?: number;
 }
 
 /**
@@ -21,11 +23,13 @@ export type CommonDuration = string | number;
 
 export class OnvifError extends Error {
   public readonly xml?: string;
+  public readonly statusCode?: number;
   constructor(message: string, options?: OnvifErrorOptions) {
     super(message);
     this.name = 'OnvifError';
     if (options) {
       this.xml = options.xml;
+      this.statusCode = options.statusCode;
     }
   }
 }
@@ -272,6 +276,11 @@ function hydrateStopNode(value: any, options: ParseSOAPStringOptions): any {
 export async function parseSOAPString<T>(xml: string, options?: ParseSOAPStringOptions): Promise<[T, string]> {
   /* Filter out xml namespaces */
   // const xml = rawXml.replace(/xmlns([^=]*?)=(".*?")/g, '');
+  if (!xml?.trim()) {
+    throw new OnvifError('Empty ONVIF SOAP response (camera returned no body)', {
+      xml: xml ?? '',
+    });
+  }
   const result = parse(xml, options);
   formatXMLValues(result, options);
   const body = result.envelope?.body;
@@ -325,17 +334,56 @@ export function struct<T, K extends keyof T>(list: T[], groupKey: K): Record<str
 //   return builder.buildObject(object);
 // }
 
+// Compact SOAP like v0.x (no pretty-print). Some cameras (e.g. Pelco) reject or
+// mishandle indented SOAP and return an empty HTTP body — see #497.
 const newBuilder = new XMLBuilder({
   ignoreAttributes: false,
   attributesGroupName: '$',
   attributeNamePrefix: '',
   textNodeName: '_',
-  format: true,
-  indentBy: '  ',
+  format: false,
+  suppressEmptyNode: true,
 });
 
 export function build(object: any) {
   return newBuilder.build(object);
+}
+
+/**
+ * Derive SOAP 1.2 `action` URI from a request body object (first child of Body + its xmlns).
+ * Matches v0.x Content-Type `action="namespace/Operation"` behaviour.
+ */
+export function soapActionFromBody(body: Record<string, any>, fallbackXmlns?: string): string | undefined {
+  const keys = Object.keys(body).filter((key) => key !== '$');
+  if (keys.length === 0) {
+    return undefined;
+  }
+  const operation = keys[0];
+  const xmlns = body[operation]?.$?.xmlns ?? fallbackXmlns;
+  if (!xmlns || typeof xmlns !== 'string') {
+    return undefined;
+  }
+  return `${xmlns}/${operation}`;
+}
+
+/**
+ * Derive SOAP 1.2 `action` from a pre-built envelope string (rawRequest paths).
+ */
+export function soapActionFromXml(xml: string): string | undefined {
+  const bodyMatch = xml.match(/<(?:[\w-]+:)?Body\b[^>]*>([\s\S]*?)<\/(?:[\w-]+:)?Body>/i);
+  if (!bodyMatch) {
+    return undefined;
+  }
+  const opMatch = bodyMatch[1].match(/<([\w-]+)([^>]*)\/?>/);
+  if (!opMatch) {
+    return undefined;
+  }
+  const local = opMatch[1].includes(':') ? opMatch[1].split(':').pop()! : opMatch[1];
+  const nsMatch = opMatch[2].match(/\bxmlns(?::\w+)?="([^"]+)"/);
+  if (!nsMatch) {
+    return undefined;
+  }
+  return `${nsMatch[1]}/${local}`;
 }
 
 /**


### PR DESCRIPTION
Got it!
Fixes[ #497](https://github.com/agsh/onvif/issues/497) - some cameras (Pelco) were answering with an empty body after connect.
v1 was sending Content-Type without charset/SOAP action and pretty-printed SOAP; v0 sent compact XML with action=…/GetServices. 
Restored that, and if the body is still empty the error now includes the HTTP status.
The Nonce “missing quote” in the issue looks like VS Code truncating a long string in the debugger, not broken outbound XML.
Added tests for the Content-Type/action path and empty responses.